### PR TITLE
Update live editing packages

### DIFF
--- a/live-editing/services/DependencyResolver.ts
+++ b/live-editing/services/DependencyResolver.ts
@@ -1,5 +1,6 @@
 // tslint:disable:prefer-const
 // tslint:disable:prefer-for-of
+// tslint:disable:no-implicit-dependencies
 import * as fs from "fs";
 import * as path from "path";
 import * as Collections from "typescript-collections";
@@ -24,6 +25,7 @@ const COMMON_PACKAGE_DEPENDENCIES = [
     "classlist.js",
     "core-js",
     "hammerjs",
+    "@types/hammerjs",
     "intl",
     "web-animations-js"
 ];
@@ -37,6 +39,9 @@ const DEFAULT_DEPENDENCIES = [
     "hammerjs",
     "web-animations-js",
     "jszip",
+    // importing this temporarily until we resolve the issue
+    // https://github.com/IgniteUI/igniteui-angular-samples/issues/234
+    "immediate",
     "intl",
     "tslib"
 ];


### PR DESCRIPTION
This PR fixes StackBlitz on prod (#396), but does not close any issues because further investigation is needed.
PR info:
- Added `@types/hammerjs` package. Related to #396. We are not closing this issue, we'll do further research why this package is needed in 6.0.1 but not in 6.0.0
- Added `immeadiate` package. Related to #234. We're not closing this issue as well. This is needed in all grid samples from 6.0.1 on. In 6.0.0 we needed it in Excel/CSV exporting where it is separately added.. It is suspected `jszip` library is not correctly imported in `igniteui-angular` package.
