### PR TITLE
fix(samples): Fix dragging chip selects all the text in StackBlitz

### DIFF
--- a/src/app/chip/chip.component.scss
+++ b/src/app/chip/chip.component.scss
@@ -4,6 +4,12 @@
     margin: 0 auto;
     width: 700px;
     display: block;
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
 }
 .chiparea{
     width: 640px;


### PR DESCRIPTION
Closes #490 