### PR TITLE
docs(tabs): Fixed styling issues, IE issue with missing labels #622

### DIFF
--- a/src/app/tabs/tabs-sample-4/components/tabs-sample-4.component.html
+++ b/src/app/tabs/tabs-sample-4/components/tabs-sample-4.component.html
@@ -4,9 +4,8 @@
     <igx-tabs #tabs1>
         <igx-tabs-group *ngFor="let routerLink of routerLinks">
             <ng-template igxTab>
-                <a routerLink="{{routerLink.link}}">
-                    {{routerLink.label}}
-                </a>
+                {{routerLink.label}}
+                <a routerLink="{{routerLink.link}}"></a>
             </ng-template>
         </igx-tabs-group>
     </igx-tabs>

--- a/src/app/tabs/tabs-sample-4/components/tabs-sample-4.component.ts
+++ b/src/app/tabs/tabs-sample-4/components/tabs-sample-4.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from "@angular/core";
+import { Component, OnDestroy, OnInit, ViewChild } from "@angular/core";
 import { NavigationEnd, Router } from "@angular/router";
 import { IgxTabsComponent, IgxTabsGroupComponent } from "igniteui-angular";
 import { Subscription } from "rxjs";
@@ -9,7 +9,7 @@ import { filter } from "rxjs/operators";
     styleUrls: ["./tabs-sample-4.component.scss"],
     templateUrl: "./tabs-sample-4.component.html"
 })
-export class TabsSample4Component implements OnInit {
+export class TabsSample4Component implements OnInit, OnDestroy {
     @ViewChild("tabs1")
     public tabs: IgxTabsComponent;
     public routerLinks: any[];


### PR DESCRIPTION
1. Open first routing sample in IE and expect tabs - labels are missing - now are fixed 
2. Tabs labels are not longer underlined

Related to IgniteUI/igniteui-angular#1957