### PR TITLE
Add theming for calendar

### DIFF
--- a/src/app/theming/dark-theme-sample/dark-theme-sample.component.html
+++ b/src/app/theming/dark-theme-sample/dark-theme-sample.component.html
@@ -28,7 +28,7 @@
     <div class="grid-options" igxLayout igxLayoutDir="row" igxLayoutWrap="wrap">
         <button igxButton="raised" class="addProdBtn" (click)="openDialog()">Add New Product</button>
     </div>
-    <igx-grid [data]="data" [autoGenerate]="false" height="500px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
+    <igx-grid [data]="data" [autoGenerate]="false" height="550px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
         #grid1>
         <igx-column [field]="'IndustrySector'" dataType="string" [filterable]="true" [sortable]="true"></igx-column>
         <igx-column [field]="'IndustryGroup'" dataType="string" [filterable]="true" [sortable]="true" [editable]="true"></igx-column>

--- a/src/app/theming/default-theme-sample/default-theme-sample.component.html
+++ b/src/app/theming/default-theme-sample/default-theme-sample.component.html
@@ -28,7 +28,7 @@
     <div class="grid-options" igxLayout igxLayoutDir="row" igxLayoutWrap="wrap">
         <button igxButton="raised" class="addProdBtn" (click)="openDialog()">Add New Product</button>
     </div>
-    <igx-grid [data]="data" [autoGenerate]="false" height="500px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
+    <igx-grid [data]="data" [autoGenerate]="false" height="550px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
         #grid1>
         <igx-column [field]="'IndustrySector'" dataType="string" [filterable]="true" [sortable]="true"></igx-column>
         <igx-column [field]="'IndustryGroup'" dataType="string" [filterable]="true" [sortable]="true" [editable]="true"></igx-column>

--- a/src/app/theming/styles/dark-theme-class.scss
+++ b/src/app/theming/styles/dark-theme-class.scss
@@ -6,7 +6,7 @@
     //Set the dark themes for the components.
     &.dark-theme {
         background: $dark-color;
-        ::ng-deep {   
+        ::ng-deep {
           @include igx-grid($dark-grid-theme);
           @include igx-grid-paginator($dark-grid-paginator-theme);
           @include igx-grid-filtering($dark-grid-filtering-theme);
@@ -14,7 +14,8 @@
           @include igx-input-group($dark-input-group-theme);
           @include igx-snackbar($dark-snackbar-theme);
           @include igx-button($dark-button-theme);
-          @include igx-button-group($dark-button-group-theme); 
+          @include igx-button-group($dark-button-group-theme);
+          @include igx-calendar($dark-calendar-theme);
         }
       }
 }

--- a/src/app/theming/styles/dark-theme.scss
+++ b/src/app/theming/styles/dark-theme.scss
@@ -33,6 +33,10 @@
 @import '~igniteui-angular/lib/core/styles//components/button-group/button-group-component';
 @import '~igniteui-angular/lib/core/styles//components/button-group/button-group-theme';
 
+// Import calendar component and theme styles
+@import '~igniteui-angular/lib/core/styles/components/calendar/calendar-component';
+@import '~igniteui-angular/lib/core/styles/components/calendar/calendar-theme';
+
 // Define the primary colors
 $dark-color: #282828;
 
@@ -117,4 +121,9 @@ $icon-focus-color: igx-color($dark-theme-palette, "primary", 500),
 $icon-focus-background: igx-color($dark-theme-palette, "secondary", 500),
 $disabled-background: igx-color($dark-theme-palette, "primary", 400),
 $disabled-color: igx-color($dark-theme-palette, "primary", 700)
+);
+
+// Define dark theme for the calendar
+$dark-calendar-theme: igx-calendar-theme(
+    $palette: $dark-theme-palette
 );

--- a/src/app/theming/styles/theme-classes.scss
+++ b/src/app/theming/styles/theme-classes.scss
@@ -5,27 +5,28 @@
     display: block;
     margin: 16px;
     box-shadow: igx-elevation($elevations, 12);
-   
-  
-  //Set the light themes for the components. 
+
+
+  //Set the light themes for the components.
     &.light-theme {
       background: $light-color;
-      ::ng-deep {   
+      ::ng-deep {
         @include igx-grid($light-grid-theme);
-        @include igx-snackbar($light-snackbar-theme); 
+        @include igx-snackbar($light-snackbar-theme);
         @include igx-input-group($light-input-group-theme);
         @include igx-grid-paginator($light-grid-paginator-theme);
         @include igx-button($light-button-theme);
         @include igx-dialog($light-dialog-theme);
         @include igx-grid-filtering($light-grid-filtering-theme);
-        @include igx-button-group($light-button-group-theme);     
+        @include igx-button-group($light-button-group-theme);
+        @include igx-calendar($light-calendar-theme);
       }
     }
-  
+
     //Set the dark themes for the components.
     &.dark-theme {
       background: $dark-color;
-      ::ng-deep {   
+      ::ng-deep {
         @include igx-grid($dark-grid-theme);
         @include igx-snackbar($dark-snackbar-theme);
         @include igx-input-group($dark-input-group-theme);
@@ -33,14 +34,15 @@
         @include igx-button($dark-button-theme);
         @include igx-dialog($dark-dialog-theme);
         @include igx-grid-filtering($dark-grid-filtering-theme);
-        @include igx-button-group($dark-button-group-theme); 
+        @include igx-button-group($dark-button-group-theme);
+        @include igx-calendar($dark-calendar-theme);
       }
     }
-  
+
      //Set the black themes for the components.
     &.black-theme {
       background: $black-color;
-      ::ng-deep {    
+      ::ng-deep {
         @include igx-grid($black-grid-theme);
         @include igx-snackbar($black-snackbar-theme);
         @include igx-input-group($black-input-group-theme);
@@ -48,8 +50,8 @@
         @include igx-button($black-button-theme);
         @include igx-dialog($black-dialog-theme);
         @include igx-grid-filtering($black-grid-filtering-theme);
-        @include igx-button-group($black-button-group-theme); 
+        @include igx-button-group($black-button-group-theme);
+        @include igx-calendar($black-calendar-theme);
       }
     }
   }
-  

--- a/src/app/theming/styles/themes.scss
+++ b/src/app/theming/styles/themes.scss
@@ -37,6 +37,10 @@
 @import '~igniteui-angular/lib/core/styles//components/drop-down/drop-down-component';
 @import '~igniteui-angular/lib/core/styles//components/drop-down/drop-down-theme';
 
+// Import calendar component and theme styles
+@import '~igniteui-angular/lib/core/styles/components/calendar/calendar-component';
+@import '~igniteui-angular/lib/core/styles/components/calendar/calendar-theme';
+
 // Define the primary colors
 $light-color: #F8F8F8;
 $dark-color: #282828;
@@ -80,7 +84,7 @@ $light-dialog-theme: igx-dialog-theme(
   $palette: $light-theme-palette,
   $background: igx-color($light-theme-palette, "primary", 100),
   $title-color: igx-color($light-theme-palette, "secondary", 500),
-  $message-color: igx-color($light-theme-palette, "secondary", 600) 
+  $message-color: igx-color($light-theme-palette, "secondary", 600)
 );
 
 // Define dark theme for the dialog
@@ -264,7 +268,7 @@ $light-grid-filtering-theme: igx-grid-filtering-theme(
   $menu-background: igx-color($light-theme-palette, "primary", 100),
   $menu-text-color: igx-color($light-theme-palette, "secondary", 500),
   $menu-button-text-color: igx-color($light-theme-palette, "secondary", 500),
-  $menu-button-disabled-text-color: igx-color($light-theme-palette, "secondary", 500)	
+  $menu-button-disabled-text-color: igx-color($light-theme-palette, "secondary", 500)
 );
 
 // Define dark theme for the grid-filtering
@@ -288,4 +292,16 @@ $black-grid-filtering-theme: igx-grid-filtering-theme(
   $menu-text-color: igx-color($black-theme-palette, "secondary", 500),
   $menu-button-text-color: igx-color($black-theme-palette, "secondary", 500),
   $menu-button-disabled-text-color: igx-color($black-theme-palette, "secondary", 700)
-  );
+);
+
+$light-calendar-theme: igx-calendar-theme(
+    $palette: $light-theme-palette
+);
+
+$dark-calendar-theme: igx-calendar-theme(
+    $palette: $dark-theme-palette
+);
+
+$black-calendar-theme: igx-calendar-theme(
+    $palette: $black-theme-palette
+);

--- a/src/app/theming/theme-chooser/theme-chooser-sample.component.html
+++ b/src/app/theming/theme-chooser/theme-chooser-sample.component.html
@@ -38,7 +38,7 @@
                 </igx-drop-down-item>
             </igx-drop-down>
         </div>
-        <igx-grid [data]="data" [autoGenerate]="false" height="500px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
+        <igx-grid [data]="data" [autoGenerate]="false" height="550px" width="100%" [paging]="true" [perPage]="10" displayDensity="comfortable"
             #grid1>
             <igx-column [field]="'IndustrySector'" dataType="string" [filterable]="true" [sortable]="true"></igx-column>
             <igx-column [field]="'IndustryGroup'" dataType="string" [filterable]="true" [sortable]="true" [editable]="true"></igx-column>


### PR DESCRIPTION
After we've added the outlet directive we haven't added a calendar theme to the sample. This code change adds such team, and now if you go ahead and open any calendar (cell editing or Filtering) it should be with the same color of the theme.