### PR TITLE
docs(tabs): Removing tabs routing samples from navigation tree #668

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -801,12 +801,10 @@ export const samplesRoutes: Routes = [
     },
     {
         component: TabsSample4Component,
-        data: { displayName: "TabsRouting1", parentName: "Tabs" },
         path: "tabs-sample-4"
     },
     {
         component: TabsSample5Component,
-        data: { displayName: "TabsRouting2", parentName: "Tabs" },
         path: "tabs-sample-5"
     },
     {


### PR DESCRIPTION
Tabs routing samples are removed from SB navigation tree because they are used only in stackbliz separate apps.

Related to #668