### PR TITLE
adding navigator since our samples are currently running product code

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -7,6 +7,9 @@ const tsNode = require('ts-node').register({
     }
 });
 
+//  Workaround for exception with Excel samples running product code during generate-live-editing task.
+navigator = { language: "en-US" };
+
 function requireFile(path) {
     delete require.cache[require.resolve(path)];
     return require(path);


### PR DESCRIPTION
Since the generate-live-editing task ends up running some product code, temporarily implementing this workaround so we can push the samples.