### PR TITLE
Adding explicit width to tree grid samples for proper render in IE 11.

### DIFF
--- a/src/app/tree-grid/tree-grid-childdatakey-sample/tree-grid-childdatakey-sample.component.html
+++ b/src/app/tree-grid/tree-grid-childdatakey-sample/tree-grid-childdatakey-sample.component.html
@@ -3,8 +3,8 @@
                    [autoGenerate]="false" [rowSelectable]="true" [paging]="true" [allowFiltering]="true"
                    [showToolbar]="true" toolbarTitle="Employees" [columnHiding]="true" [columnPinning]="true"
                    [exportExcel]="true" [exportCsv]="true" exportExcelText="To Excel" exportCsvText="To CSV">
-        <igx-column field="Name" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" [hasSummary]="true"></igx-column>
-        <igx-column field="HireDate" dataType="date" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true"></igx-column>
-        <igx-column field="Age" dataType="number" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true"></igx-column>
+        <igx-column field="Name" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" [hasSummary]="true" width="33%"></igx-column>
+        <igx-column field="HireDate" dataType="date" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" width="34%"></igx-column>
+        <igx-column field="Age" dataType="number" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" width = "33%"></igx-column>
     </igx-tree-grid>
 </div>

--- a/src/app/tree-grid/tree-grid-primaryforeignkey-sample/tree-grid-primaryforeignkey-sample.component.html
+++ b/src/app/tree-grid/tree-grid-primaryforeignkey-sample/tree-grid-primaryforeignkey-sample.component.html
@@ -2,8 +2,8 @@
     <igx-tree-grid #treeGrid [data]="data" [allowFiltering]="true"
         primaryKey="ID" foreignKey="ParentID" width="100%" height="400px"
         [rowSelectable]="true">
-        <igx-column field="Name" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true"></igx-column>
-        <igx-column field="JobTitle" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true"></igx-column>
-        <igx-column field="Age" dataType="number" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true"></igx-column>
+        <igx-column field="Name" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" width="33%"></igx-column>
+        <igx-column field="JobTitle" dataType="string" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" width="34%"></igx-column>
+        <igx-column field="Age" dataType="number" [sortable]="true" [editable]="true" [movable]="true" [resizable]="true" width="33%"></igx-column>
     </igx-tree-grid>
 </div>

--- a/src/app/tree-grid/tree-grid-row-edit/tree-grid-row-editing-sample.component.html
+++ b/src/app/tree-grid/tree-grid-row-edit/tree-grid-row-editing-sample.component.html
@@ -15,6 +15,7 @@
             [resizable]="c.resizable"
             [sortable]="c.sortable"
             [filterable]="c.filterable"
+            width="25%"
             >
         </igx-column>
     </igx-tree-grid>


### PR DESCRIPTION
Closes #837 