### PR TITLE
Set close on outside click to false

### DIFF
--- a/src/app/interactions/toggle/toggle.component.ts
+++ b/src/app/interactions/toggle/toggle.component.ts
@@ -21,7 +21,7 @@ export class ToggleComponent {
         verticalStartPoint: VerticalAlignment.Bottom
     };
     public _overlaySettings = {
-        closeOnOutsideClick: true,
+        closeOnOutsideClick: false,
         modal: false,
         positionStrategy: new ConnectedPositioningStrategy(this._positionSettings),
         scrollStrategy: new CloseScrollStrategy()


### PR DESCRIPTION
We have toggle button and it is not compatible with close on outside click. This is why I changed the `closeOnOutsideClick` from `true` to `false`.