### PR TITLE
fix(igxSelect): Better items positioning illustration( with less items)

### DIFF
--- a/src/app/data-entries/select/select-sample-1/select-sample-1.component.ts
+++ b/src/app/data-entries/select/select-sample-1/select-sample-1.component.ts
@@ -6,5 +6,5 @@ import { Component } from "@angular/core";
     templateUrl: "select-sample-1.component.html"
 })
 export class SelectSample1Component {
-    public items: string[] = ["Orange", "Apple", "Banana", "Mango", "Pineapple"];
+    public items: string[] = ["Orange", "Apple", "Banana", "Mango"];
 }


### PR DESCRIPTION
Use less items instead of setting more sample height to position the first/last selected items correctly for the illustration purposes.