### PR TITLE
chore(card): Add display:block to Card Sample 1 host

### DIFF
--- a/src/app/layouts/card/card-sample-1/card-sample-1.component.scss
+++ b/src/app/layouts/card/card-sample-1/card-sample-1.component.scss
@@ -2,3 +2,7 @@
     max-width: 400px;
     min-width: 250px;
 }
+
+:host {
+    display: block;
+}


### PR DESCRIPTION
The card-sample-1.component.ts is used inside of a couple of overlay examples. It needs to have display:block. Otherwise, the overlay animations do no properly play when showing or hiding the component