### PR TITLE
Fix BaseConfigGenerator providers imports and configure Sparkline and GeoMap configs

### DIFF
--- a/live-editing/configs/GeoMapConfigGenerator.ts
+++ b/live-editing/configs/GeoMapConfigGenerator.ts
@@ -5,12 +5,6 @@
 // tslint:disable:prefer-const
 import { IgxGeographicMapModule } from "igniteui-angular-maps/ES5/igx-geographic-map-module";
 
-import { WorldUtility } from "../../src/app/utilities/WorldUtility";
-import { WorldConnections } from "../../src/app/utilities/WorldConnections";
-import { WorldLocations } from "../../src/app/utilities/WorldLocations";
-import { MapUtility } from "../../src/app/utilities/MapUtility";
-import { EsriUtility, EsriStyle } from "../../src/app/utilities/EsriUtility";
-
 import { MapBindingDataCsvComponent } from "../../src/app/maps/geo-map-binding-data-csv/map-binding-data-csv.component";
 import { MapBindingDataJsonPointsComponent } from "../../src/app/maps/geo-map-binding-data-json-points/map-binding-data-json-points.component";
 import { MapBindingDataModelComponent } from "../../src/app/maps/geo-map-binding-data-model/map-binding-data-model.component";
@@ -29,13 +23,13 @@ import { MapTypeScatterSymbolSeriesComponent } from "../../src/app/maps/geo-map-
 import { MapTypeShapePolygonSeriesComponent } from "../../src/app/maps/geo-map-type-shape-polygon-series/map-type-shape-polygon-series.component";
 import { MapTypeShapePolylineSeriesComponent } from "../../src/app/maps/geo-map-type-shape-polyline-series/map-type-shape-polyline-series.component";
 
-import { MapDisplayImageryOSM } from "../../src/app/maps/MapDisplayImageryOSM/component";
 import { MapDisplayImageryBingTiles } from "../../src/app/maps/MapDisplayImageryBingTiles/component";
 import { MapDisplayImageryEsriTiles } from "../../src/app/maps/MapDisplayImageryEsriTiles/component";
+import { MapDisplayImageryOSM } from "../../src/app/maps/MapDisplayImageryOSM/component";
 
-import { Config } from "./core/Config";
 import { DependenciesType } from "../services/DependenciesType";
 import { BaseConfigGenerator } from "./core/BaseConfigGenerator";
+import { Config } from "./core/Config";
 
 export class GeoMapConfigGenerator extends BaseConfigGenerator {
 
@@ -88,8 +82,8 @@ export class GeoMapConfigGenerator extends BaseConfigGenerator {
              "/src/assets/Shapes/WorldTemperatures.dbf"]));
         configs.push(this.getConfig(
             MapTypeScatterSymbolSeriesComponent,
-            [IgxGeographicMapModule],
-            [WorldLocations], ["/src/app/utilities/WorldLocations.ts"]));
+            [IgxGeographicMapModule], null,
+            ["/src/app/utilities/WorldLocations.ts"]));
         configs.push(this.getConfig(
             MapTypeShapePolygonSeriesComponent,
             [IgxGeographicMapModule], null,
@@ -104,7 +98,8 @@ export class GeoMapConfigGenerator extends BaseConfigGenerator {
         configs.push(this.getConfig(
             MapTypeScatterDensitySeriesComponent,
             [IgxGeographicMapModule], null,
-            ["/src/assets/Data/AusPlaces.json"]));
+            ["/src/assets/Data/AusPlaces.json",
+             "/src/app/utilities/WorldUtility.ts"]));
 
         configs.push(this.getConfig(
             MapOverviewComponent,
@@ -116,8 +111,10 @@ export class GeoMapConfigGenerator extends BaseConfigGenerator {
 
         configs.push(this.getConfig(
             MapBindingMultipleSourcesComponent,
-            [IgxGeographicMapModule],
-            [WorldConnections], ["/src/app/utilities/WorldConnections.ts"]));
+            [IgxGeographicMapModule], null,
+            ["/src/app/utilities/WorldConnections.ts",
+             "/src/app/utilities/WorldLocations.ts",
+             "/src/app/utilities/WorldUtility.ts"]));
 
         configs.push(this.getConfig(
             MapBindingDataCsvComponent,
@@ -131,20 +128,20 @@ export class GeoMapConfigGenerator extends BaseConfigGenerator {
 
         configs.push(this.getConfig(
             MapBindingDataModelComponent,
-            [IgxGeographicMapModule],
-            [WorldUtility], ["/src/app/utilities/WorldUtility.ts"]));
+            [IgxGeographicMapModule], null,
+            ["/src/app/utilities/WorldUtility.ts"]));
 
         configs.push(this.getConfig(
             MapDisplayImageryOSM,
             [IgxGeographicMapModule]));
         configs.push(this.getConfig(
             MapDisplayImageryBingTiles,
-            [IgxGeographicMapModule],
-            [MapUtility], ["/src/app/utilities/MapUtility.ts"]));
+            [IgxGeographicMapModule], null,
+            ["/src/app/utilities/MapUtility.ts"]));
         configs.push(this.getConfig(
             MapDisplayImageryEsriTiles,
-            [IgxGeographicMapModule],
-            [EsriUtility], ["/src/app/utilities/EsriUtility.ts"]));
+            [IgxGeographicMapModule], null,
+            ["/src/app/utilities/EsriUtility.ts"]));
 
         return configs;
     }

--- a/live-editing/configs/SparklineConfigGenerator.ts
+++ b/live-editing/configs/SparklineConfigGenerator.ts
@@ -4,18 +4,17 @@
 // tslint:disable:member-ordering
 // tslint:disable:prefer-const
 
-import { IgxFinancialChartModule } from "igniteui-angular-charts/ES5/igx-financial-chart-module";
+import { IgxSparklineModule} from "igniteui-angular-charts/ES5/igx-sparkline-module";
 
-import { SharedData } from "../../src/app/charts/sparkline/SharedData";
 import { SparklineDisplayTypesComponent } from "../../src/app/charts/sparkline/sparkline-display-types/sparkline-display-types.component";
 import { SparklineMarkersComponent } from "../../src/app/charts/sparkline/sparkline-markers/sparkline-markers.component";
 import { SparklineNormalRangeComponent } from "../../src/app/charts/sparkline/sparkline-normal-range/sparkline-normal-range.component";
 import { SparklineTrendlinesComponent } from "../../src/app/charts/sparkline/sparkline-trendlines/sparkline-trendlines.component";
 import { SparklineUnknownValuesComponent } from "../../src/app/charts/sparkline/sparkline-unknown-values/sparkline-unknown-values.component";
 
-import { Config } from "./core/Config";
 import { DependenciesType } from "../services/DependenciesType";
 import { BaseConfigGenerator } from "./core/BaseConfigGenerator";
+import { Config } from "./core/Config";
 
 export class SparklineConfigGenerator extends BaseConfigGenerator {
 
@@ -28,28 +27,28 @@ export class SparklineConfigGenerator extends BaseConfigGenerator {
 
         configs.push(this.getConfig(
             SparklineDisplayTypesComponent,
-            [IgxFinancialChartModule],
-            [SharedData], ["/src/app/charts/sparkline/SharedData.ts"]));
+            [IgxSparklineModule], null,
+            ["/src/app/charts/sparkline/SharedData.ts"]));
 
         configs.push(this.getConfig(
             SparklineMarkersComponent,
-            [IgxFinancialChartModule],
-            [SharedData], ["/src/app/charts/sparkline/SharedData.ts"]));
+            [IgxSparklineModule], null,
+            ["/src/app/charts/sparkline/SharedData.ts"]));
 
         configs.push(this.getConfig(
             SparklineNormalRangeComponent,
-            [IgxFinancialChartModule],
-            [SharedData], ["/src/app/charts/sparkline/SharedData.ts"]));
+            [IgxSparklineModule], null,
+            ["/src/app/charts/sparkline/SharedData.ts"]));
 
         configs.push(this.getConfig(
             SparklineTrendlinesComponent,
-            [IgxFinancialChartModule],
-            [SharedData], ["/src/app/charts/sparkline/SharedData.ts"]));
+            [IgxSparklineModule], null,
+            ["/src/app/charts/sparkline/SharedData.ts"]));
 
         configs.push(this.getConfig(
             SparklineUnknownValuesComponent,
-            [IgxFinancialChartModule],
-            [SharedData], ["/src/app/charts/sparkline/SharedData.ts"]));
+            [IgxSparklineModule], null,
+            ["/src/app/charts/sparkline/SharedData.ts"]));
 
         return configs;
     }

--- a/live-editing/configs/core/BaseConfigGenerator.ts
+++ b/live-editing/configs/core/BaseConfigGenerator.ts
@@ -33,7 +33,7 @@ export abstract class BaseConfigGenerator implements IConfigGenerator {
         for (const m of modules) {
             imports.push(m); // add modules for importing
         }
-        // add optional data sources
+        // add optional services to the app-module.ts imports
         if (services !== undefined &&
             services !== null &&
             services.length > 0) {

--- a/live-editing/configs/core/BaseConfigGenerator.ts
+++ b/live-editing/configs/core/BaseConfigGenerator.ts
@@ -25,7 +25,7 @@ export abstract class BaseConfigGenerator implements IConfigGenerator {
               [SharedData], ["/src/app/charts/data-chart/SharedData.ts"]
     )); */
     public getConfig(
-        mainComponent: Type<any>, modules: any[], dataSources?: any[], dataPaths?: string[],
+        mainComponent: Type<any>, modules: any[], services?: any[], additionalFilesPaths?: string[],
         otherComponents?: Array<Type<any>>) {
 
         const imports: any[] = [];
@@ -34,13 +34,13 @@ export abstract class BaseConfigGenerator implements IConfigGenerator {
             imports.push(m); // add modules for importing
         }
         // add optional data sources
-        // if (dataSources !== undefined &&
-        //     dataSources !== null &&
-        //     dataSources.length > 0) {
-        //     for (const ds of dataSources) {
-        //         imports.push(ds);
-        //     }
-        // }
+        if (services !== undefined &&
+            services !== null &&
+            services.length > 0) {
+            for (const s of services) {
+                imports.push(s);
+            }
+        }
 
         const declarations = [ mainComponent ];
         if (otherComponents !== undefined &&
@@ -51,13 +51,13 @@ export abstract class BaseConfigGenerator implements IConfigGenerator {
         }
 
         const fields = {
-            additionalFiles: dataPaths,
+            additionalFiles: additionalFilesPaths,
             component: mainComponent,
             appModuleConfig: new AppModuleConfig({
                 imports: imports,
                 ngDeclarations: declarations,
                 ngImports: modules,
-                ngProviders: dataSources
+                ngProviders: services
             }),
             dependenciesType: this.dependenciesType,
             shortenComponentPathBy: this.componentPathBy


### PR DESCRIPTION
Closes #1253 

This PR fixes:

- BaseConfigGenerator to import data **services**
- Rename **dataSource** to services, because we if use a dataSource that is **non-injectable** , we can just add it as an additional file. The service must be added to the providers in app-module.ts
- Rename `dataPaths` to additionalFilePaths, because we can add additional files that are not data sources (for example: another component, that we need as for our sample)
- Remove all data sources that are **non-injectable** (these are in GeoMapConfigGenerator and SparklineConfigGenerator)
- Replace FinancialChartModule with SparklineModule in SparklineConfigGenerator
