### PR TITLE
fix(combo): fix combo binding sample generator

### DIFF
--- a/live-editing/configs/ComboConfigGenerator.ts
+++ b/live-editing/configs/ComboConfigGenerator.ts
@@ -100,7 +100,7 @@ export class ComboConfigGenerator implements IConfigGenerator {
                 ngDeclarations: [ComboBindingComponent],
                 ngImports: [IgxComboModule, IgxButtonModule, IgxCardModule]
             }),
-            component: ComboFeatures,
+            component: ComboBindingComponent,
             shortenComponentPathBy: "/lists/combo/"
         }));
 


### PR DESCRIPTION
Combo binding sample did not have a correct ConfigGenerator and the StackBlitz buttons on combo.md were not working properly.