### PR TITLE
Update conditional row selectors samples and row numbering samples styles

### DIFF
--- a/src/app/grid/grid-conditional-row-selectors/grid-conditional-row-selectors-sample.component.html
+++ b/src/app/grid/grid-conditional-row-selectors/grid-conditional-row-selectors-sample.component.html
@@ -1,11 +1,6 @@
 <div class="grid__wrapper">
-    <igx-grid [data]="data"
-            height="530px"
-            width="100%"
-            cellSelection="none"
-            primaryKey="ID"
-            rowSelection="multiple" [paging]="true"
-            (onRowSelectionChange)="onRowSelect($event)">
+    <igx-grid [data]="data" height="530px" width="100%" cellSelection="none" primaryKey="ID" rowSelection="multiple"
+        [paging]="true" (onRowSelectionChange)="onRowSelect($event)">
         <igx-column field="ContactName" width="20%"></igx-column>
         <igx-column field="Country" width="20%"></igx-column>
         <igx-column field="City" width="20%" dataType="number"></igx-column>
@@ -13,10 +8,12 @@
         <igx-column field="CompanyName" width="20%" dataType="number"></igx-column>
 
         <ng-template igxRowSelector let-rowContext>
-            <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
-                [disabled]="!isSelectionAllowed(rowContext.rowID)"
-                [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
-            </igx-checkbox>
+            <div class="row-selector">
+                <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
+                    [disabled]="!isSelectionAllowed(rowContext.rowID)"
+                    [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
+                </igx-checkbox>
+            </div>
         </ng-template>
     </igx-grid>
 </div>

--- a/src/app/grid/grid-conditional-row-selectors/grid-conditional-row-selectors-sample.component.scss
+++ b/src/app/grid/grid-conditional-row-selectors/grid-conditional-row-selectors-sample.component.scss
@@ -1,4 +1,11 @@
 .grid__wrapper {
-    margin: 0 16px;
-    padding-top: 10px;
+  margin: 0 16px;
+  padding-top: 10px;
+}
+
+.row-selector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: calc(1.25rem + (1.5rem * 2));
 }

--- a/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.scss
+++ b/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.scss
@@ -27,7 +27,3 @@
     width: 35px;
     text-align: center;
 }
-
-::ng-deep .igx-grid__cbx-selection {
-    padding: 0;
-}

--- a/src/app/hierarchical-grid/hierarchical-grid-conditional-row-selectors/hierarchical-grid-conditional-row-selectors.component.html
+++ b/src/app/hierarchical-grid/hierarchical-grid-conditional-row-selectors/hierarchical-grid-conditional-row-selectors.component.html
@@ -1,10 +1,6 @@
 <div class="grid__wrapper">
-    <igx-hierarchical-grid [data]="singers"
-                rowSelection="multiple"
-                cellSelection="none"
-                [autoGenerate]="false" height="600px" width="100%" [paging]="true"
-                primaryKey="Artist"
-                (onRowSelectionChange)="onRowSelect($event)">
+    <igx-hierarchical-grid [data]="singers" rowSelection="multiple" cellSelection="none" [autoGenerate]="false"
+        height="600px" width="100%" [paging]="true" primaryKey="Artist" (onRowSelectionChange)="onRowSelect($event)">
         <igx-column field="Artist"></igx-column>
         <igx-column field="Debut"></igx-column>
         <igx-column field="GrammyNominations" header="Grammy Nominations"></igx-column>
@@ -31,10 +27,12 @@
         </igx-row-island>
 
         <ng-template igxRowSelector let-rowContext>
-            <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
-                [disabled]="!isSelectionAllowed(rowContext.rowID)"
-                [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
-            </igx-checkbox>
+            <div class="row-selector">
+                <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
+                    [disabled]="!isSelectionAllowed(rowContext.rowID)"
+                    [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
+                </igx-checkbox>
+            </div>
         </ng-template>
     </igx-hierarchical-grid>
 </div>

--- a/src/app/hierarchical-grid/hierarchical-grid-conditional-row-selectors/hierarchical-grid-conditional-row-selectors.component.scss
+++ b/src/app/hierarchical-grid/hierarchical-grid-conditional-row-selectors/hierarchical-grid-conditional-row-selectors.component.scss
@@ -1,4 +1,11 @@
 .grid__wrapper {
-    margin: 0 16px;
-    padding-top: 10px;
+  margin: 0 16px;
+  padding-top: 10px;
+}
+
+.row-selector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: calc(1.25rem + (1.5rem * 2));
 }

--- a/src/app/hierarchical-grid/hierarchical-grid-selection-template-numbers/hierarchical-grid-selection-template-numbers.component.scss
+++ b/src/app/hierarchical-grid/hierarchical-grid-selection-template-numbers/hierarchical-grid-selection-template-numbers.component.scss
@@ -27,7 +27,3 @@
     width: 20px;
     text-align: center;
 }
-
-::ng-deep .igx-grid__cbx-selection {
-    padding: 0;
-}

--- a/src/app/tree-grid/tree-grid-conditional-row-selectors/tree-grid-conditional-row-selectors.component.html
+++ b/src/app/tree-grid/tree-grid-conditional-row-selectors/tree-grid-conditional-row-selectors.component.html
@@ -1,12 +1,6 @@
 <div class="grid__wrapper">
-    <igx-tree-grid
-            [data]="employees"
-            rowSelection="multiple"
-            cellSelection="none"
-            primaryKey="ID" foreignKey="ParentID"
-            height="530px" width="100%"
-            [autoGenerate]="false" [paging]="true"
-            (onRowSelectionChange)="onRowSelect($event)">
+    <igx-tree-grid [data]="employees" rowSelection="multiple" cellSelection="none" primaryKey="ID" foreignKey="ParentID"
+        height="530px" width="100%" [autoGenerate]="false" [paging]="true" (onRowSelectionChange)="onRowSelect($event)">
         <igx-column field="Name"></igx-column>
         <igx-column field="Title"></igx-column>
         <igx-column field="HireDate"></igx-column>
@@ -14,10 +8,12 @@
         <igx-column field="OnPTO" width="15%"></igx-column>
 
         <ng-template igxRowSelector let-rowContext>
-            <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
-                [disabled]="!isSelectionAllowed(rowContext.rowID)"
-                [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
-            </igx-checkbox>
+            <div class="row-selector">
+                <igx-checkbox [readonly]="true" [checked]="rowContext.selected"
+                    [disabled]="!isSelectionAllowed(rowContext.rowID)"
+                    [aria-label]="rowContext.selected ? 'Deselect row' : 'Select row'">
+                </igx-checkbox>
+            </div>
         </ng-template>
     </igx-tree-grid>
 </div>

--- a/src/app/tree-grid/tree-grid-conditional-row-selectors/tree-grid-conditional-row-selectors.component.scss
+++ b/src/app/tree-grid/tree-grid-conditional-row-selectors/tree-grid-conditional-row-selectors.component.scss
@@ -1,4 +1,11 @@
 .grid__wrapper {
-    margin: 0 16px;
-    padding-top: 10px;
+  margin: 0 16px;
+  padding-top: 10px;
+}
+
+.row-selector {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-width: calc(1.25rem + (1.5rem * 2));
 }

--- a/src/app/tree-grid/tree-grid-selection-template-numbers/tree-grid-selection-template-numbers.component.scss
+++ b/src/app/tree-grid/tree-grid-selection-template-numbers/tree-grid-selection-template-numbers.component.scss
@@ -27,7 +27,3 @@
     width: 25px;
     text-align: center;
 }
-
-::ng-deep .igx-grid__cbx-selection {
-    padding: 0;
-}


### PR DESCRIPTION
By having moved padding on the default template https://github.com/IgniteUI/igniteui-angular/pull/5814 we no longer need to use `ng-deep` in the samples to apply `padding: 0`. We also have to make sure that every custom row/header template has padding applied to it. 

The conditional row selector samples did not have padding on the custom row selector template and this PR fixes this. This PR also removes the now redundant `ng-deep` declarations.
