### PR TITLE
Fixing #1580 - [Combo] Combo in grid editing sample is not properly bound

### DIFF
--- a/src/app/grid/grid-editing-sample/grid-editing-sample.component.html
+++ b/src/app/grid/grid-editing-sample/grid-editing-sample.component.html
@@ -11,7 +11,7 @@
                     {{ parseArray(cell.value) }}
                 </ng-template>
                 <ng-template igxCellEditor let-cell="cell" let-value>
-                    <igx-combo type="line" [(ngModel)]="cell.editValue" [valueKey]="'shop'" [data]="locations" width="220px"></igx-combo>
+                    <igx-combo type="line" [(ngModel)]="cell.editValue" [displayKey]="'shop'" [data]="locations" width="220px"></igx-combo>
                 </ng-template>
             </igx-column>
             <igx-column field="OrderDate" header="Order Date" [dataType]="'date'" [sortable]="true" [hasSummary]="true" [editable]="true" [resizable]="true">
@@ -44,7 +44,7 @@
                     <label igxLabel for="unitsInStock">Units In Stock</label>
                     <input igxInput id="unitsInStock" type="number" [(ngModel)]="product.UnitsInStock" />
                 </igx-input-group>
-                <igx-combo id="availableAt" [valueKey]="'shop'" [placeholder]="'Available @'" [data]="locations" [(ngModel)]="product.Locations" [itemsMaxHeight]="200"></igx-combo>
+                <igx-combo id="availableAt" [displayKey]="'shop'" [placeholder]="'Available @'" [data]="locations" [(ngModel)]="product.Locations" [itemsMaxHeight]="200"></igx-combo>
                 <igx-date-picker id="orderDate" label="Order Date" [(ngModel)]="product.OrderDate"></igx-date-picker>
                 <igx-checkbox id="discontinued" [(ngModel)]="product.Discontinued">Discontinued</igx-checkbox>
                 <igx-input-group>


### PR DESCRIPTION
Fix for issue #1580.
Changing [valueKey] to [displayKey] for the combo editor.