### PR TITLE
Removing the dark overlay when loading to vNext

### DIFF
--- a/src/app/grid/grid-remote-filtering-sample/remote-filtering-sample.component.scss
+++ b/src/app/grid/grid-remote-filtering-sample/remote-filtering-sample.component.scss
@@ -32,3 +32,12 @@
 .badge-left {
     float: left;
 }
+
+:host {
+    ::ng-deep {
+        .igx-overlay__wrapper--modal {
+            background: none;
+            pointer-events: initial;
+        }
+    }
+}


### PR DESCRIPTION
Removes dark overlay when sorting remote filtering to vNext