### PR TITLE
Fixes financial sample's slider labels' colors when a dark theme is applied - vNext

### DIFF
--- a/projects/app-lob/src/app/grid-finjs/grid-finjs-demo.component.scss
+++ b/projects/app-lob/src/app/grid-finjs/grid-finjs-demo.component.scss
@@ -169,6 +169,9 @@
     }
     .control-item {
         padding-right: 20px;
+        label {
+            color: var(--igx-surface-500-contrast);
+        }
     }
     .igx-slider,
     .igx-slider--disabled {


### PR DESCRIPTION
Related issue: #1756 