### PR TITLE
fix(drop-down): remote sample use proper unique value binding - master

### DIFF
--- a/src/app/data-entries/dropdown/drop-down-remote-virtual/drop-down-remote.component.html
+++ b/src/app/data-entries/dropdown/drop-down-remote-virtual/drop-down-remote.component.html
@@ -3,13 +3,13 @@
     <div class="drop-down-virtual-wrapper">
         <igx-drop-down-item
             *igxFor="let item of rData | async; index as index; scrollOrientation: 'vertical'; containerSize: itemsMaxHeight; itemSize: itemHeight;"
-            [value]="item" role="option" [disabled]="item.disabled" [index]="index"
+            [value]="item.ProductName" role="option" [disabled]="item.disabled" [index]="index"
             (onChunkPreload)="dataLoading($event)">
             {{ item.ProductName }}
         </igx-drop-down-item>
     </div>
 </igx-drop-down>
 <div class="selection">Selected Product: <span
-        class="selection__name">{{ remoteDropDown.selectedItem?.value.ProductName }}</span>
+        class="selection__name">{{ remoteDropDown.selectedItem?.value }}</span>
 </div>
 <igx-toast #loadingToast></igx-toast>


### PR DESCRIPTION
Closes #2064

Change drop-down item to be bound to item's `ProductName` (unique key) instead of the object itself. Object reference is lost when new virtual chunk is loaded, leading to incorrect styling of selected items.