### PR TITLE
fix(select): adjust select item content display to account for lib change - vNext

### DIFF
--- a/src/app/data-entries/select/select-header-footer/select-header-footer.component.html
+++ b/src/app/data-entries/select/select-header-footer/select-header-footer.component.html
@@ -1,5 +1,5 @@
 <div class="header-footer-select-sample">
-    <igx-select>
+    <igx-select [overlaySettings]="{ outlet: element }">
         <label igxLabel>Pick your fruit</label>
         <igx-select-item *ngFor="let fruit of fruits" [value]="fruit.type" [text]="fruit.type"
             [ngSwitch]="fruit.delivery">

--- a/src/app/data-entries/select/select-header-footer/select-header-footer.component.html
+++ b/src/app/data-entries/select/select-header-footer/select-header-footer.component.html
@@ -1,7 +1,7 @@
 <div class="header-footer-select-sample">
     <igx-select [overlaySettings]="{ outlet: element }">
         <label igxLabel>Pick your fruit</label>
-        <igx-select-item *ngFor="let fruit of fruits" [value]="fruit.type" [text]="fruit.type"
+        <igx-select-item *ngFor="let fruit of fruits" [value]="fruit.type" class="select__entry" [text]="fruit.type"
             [ngSwitch]="fruit.delivery">
             {{fruit.type}}
             <igx-icon *ngSwitchCase="'flight'">flight</igx-icon>

--- a/src/app/data-entries/select/select-header-footer/select-header-footer.component.scss
+++ b/src/app/data-entries/select/select-header-footer/select-header-footer.component.scss
@@ -9,8 +9,15 @@
     margin-left: 48px;
 }
 
-.igx-drop-down__item {
-    justify-content: space-between;
+:host ::ng-deep {
+    .igx-drop-down__item {
+        .igx-drop-down__inner {
+            display: flex;
+            padding: 8px;
+            justify-content: space-between;
+            width: 100%;
+        }
+    }
 }
 
 igx-select {
@@ -91,10 +98,6 @@ $light-sample-btn-group: igx-button-group-theme(
                 color: igx-color($green-palette, "secondary", 500);
             }
         }
-    }
-
-    .igx-drop-down__item {
-        justify-content: space-between;
     }
 
     .sample-template-heading {

--- a/src/app/data-entries/select/select-header-footer/select-header-footer.component.scss
+++ b/src/app/data-entries/select/select-header-footer/select-header-footer.component.scss
@@ -10,8 +10,8 @@
 }
 
 :host ::ng-deep {
-    .igx-drop-down__item {
-        .igx-drop-down__inner {
+    .select__entry {
+        span {
             display: flex;
             padding: 8px;
             justify-content: space-between;

--- a/src/app/data-entries/select/select-header-footer/select-header-footer.component.ts
+++ b/src/app/data-entries/select/select-header-footer/select-header-footer.component.ts
@@ -1,9 +1,8 @@
-import { ChangeDetectorRef, Component, OnInit, ViewEncapsulation } from "@angular/core";
+import { ChangeDetectorRef, Component, ElementRef, OnInit } from "@angular/core";
 @Component({
     selector: "select-header-footer",
     styleUrls: ["select-header-footer.component.scss"],
-    templateUrl: "select-header-footer.component.html",
-    encapsulation: ViewEncapsulation.None
+    templateUrl: "select-header-footer.component.html"
 })
 export class SelectHeaderFooterComponent implements OnInit {
     public flightCount: number;
@@ -31,7 +30,7 @@ export class SelectHeaderFooterComponent implements OnInit {
             { type: "Watermelon", delivery: "train"}
         ];
 
-    constructor(public cdr: ChangeDetectorRef) {
+    constructor(public cdr: ChangeDetectorRef, public element: ElementRef) {
     }
 
     public ngOnInit() {

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.html
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.html
@@ -2,7 +2,7 @@
     <igx-select [overlaySettings]="{ outlet: element }" #select>
         <label igxLabel>Select With Groups</label>
         <igx-select-item-group *ngFor="let group of greengrocery" [label]="group.label">
-            <igx-select-item *ngFor="let item of group.items" [value]="item.type" [text]="item.type">
+            <igx-select-item *ngFor="let item of group.items" class="select__entry" [value]="item.type" [text]="item.type">
                 {{item.type}}
                 <igx-icon title="Local product" class="icon" color="green" *ngIf="item.origin === 'local';else templateImport">local_shipping</igx-icon>
                 <ng-template #templateImport>

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.html
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.html
@@ -1,5 +1,5 @@
 <div class="select-wrapper">
-    <igx-select #select>
+    <igx-select [overlaySettings]="{ outlet: element }" #select>
         <label igxLabel>Select With Groups</label>
         <igx-select-item-group *ngFor="let group of greengrocery" [label]="group.label">
             <igx-select-item *ngFor="let item of group.items" [value]="item.type" [text]="item.type">

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.scss
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.scss
@@ -10,12 +10,12 @@
 }
 
 :host ::ng-deep {
-    .igx-drop-down__item {
-        .igx-drop-down__inner {
+    .select__entry {
+        span {
             display: flex;
             justify-content: space-between;
             width: 100%;
-            padding-left: 12px;
+            padding-right: 12px;
         }
     }
 }

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.scss
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.scss
@@ -8,3 +8,14 @@
     padding-left: 10px;
     padding-left: 10px;
 }
+
+:host ::ng-deep {
+    .igx-drop-down__item {
+        .igx-drop-down__inner {
+            display: flex;
+            justify-content: space-between;
+            width: 100%;
+            padding-left: 12px;
+        }
+    }
+}

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.ts
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.ts
@@ -1,6 +1,6 @@
 
-import { Component, ViewChild } from "@angular/core";
-import { IgxSelectComponent, IgxSelectItemComponent } from "igniteui-angular";
+import { Component, ElementRef, ViewChild } from "@angular/core";
+import { IgxSelectComponent } from "igniteui-angular";
 
 @Component({
     selector: "select-sample-2",
@@ -10,28 +10,31 @@ import { IgxSelectComponent, IgxSelectItemComponent } from "igniteui-angular";
 export class SelectSample2Component {
     @ViewChild(IgxSelectComponent, { static: true })
     public select: IgxSelectComponent;
-
+    
     public greengrocery: Array<{
         label: string,
         items: Array<{ type: string, origin: string }>
     }> = [
-            {
-                label: "Fruits",
-                items:
-                    [
-                        { type: "Apple", origin: "local" },
-                        { type: "Orange", origin: "import" },
-                        { type: "Banana", origin: "import"}
-                    ]
-            },
-            {
-                label: "Vegetables",
-                items:
-                    [
-                        { type: "Cucumber", origin: "local" },
-                        { type: "Potato", origin: "import" },
-                        { type: "Pepper", origin: "local" }
-                    ]
-            }
-        ];
+        {
+            label: "Fruits",
+            items:
+            [
+                { type: "Apple", origin: "local" },
+                { type: "Orange", origin: "import" },
+                { type: "Banana", origin: "import"}
+            ]
+        },
+        {
+            label: "Vegetables",
+            items:
+            [
+                { type: "Cucumber", origin: "local" },
+                { type: "Potato", origin: "import" },
+                { type: "Pepper", origin: "local" }
+            ]
+        }
+    ];
+
+    constructor(public element: ElementRef) {
+    }
 }

--- a/src/app/data-entries/select/select-sample-2/select-sample-2.component.ts
+++ b/src/app/data-entries/select/select-sample-2/select-sample-2.component.ts
@@ -10,7 +10,7 @@ import { IgxSelectComponent } from "igniteui-angular";
 export class SelectSample2Component {
     @ViewChild(IgxSelectComponent, { static: true })
     public select: IgxSelectComponent;
-    
+
     public greengrocery: Array<{
         label: string,
         items: Array<{ type: string, origin: string }>


### PR DESCRIPTION
Depends on https://github.com/IgniteUI/igniteui-angular/pull/7329

With the change to the content of the `igx-drop-down__item` (and, therefore, the select item), we need to make some changes to our sample in order to preserve their look:

The content of the select item is no longer `display: flex`, so we need to manually add that.
Since the item's content is part of the `igx-drop-down-item` template, we need to penetrate view encapsulation in both samples
To prevent style from "leaking", we need to scope by ':host' and use a display `outlet` for the overlay.
Finally, one of the samples was using `ViewEncapsulation.None` and was leaking styles - this is addressed.