### PR TITLE
Navdrawer fixes for indigo theme

### DIFF
--- a/src/app/index/index.component.html
+++ b/src/app/index/index.component.html
@@ -8,10 +8,8 @@
                 </div>
 
                 <!-- Home -->
-                <span igxDrawerItem igxRipple routerLink="{{homeRouteItem.path}}" routerLinkActive="igx-nav-drawer__item--active">
-                    <button igxButton="icon" igxRipple igxRippleCentered="true">
-                        <igx-icon fontSet="material">home</igx-icon>
-                    </button>
+                <span igxDrawerItem igxRipple routerLink="{{homeRouteItem.path}}" routerLinkActive="igx-nav-drawer__item--active navdrawer-ellipsis">
+                    <igx-icon fontSet="material">home</igx-icon>
                     {{homeRouteItem.displayName}}
                 </span>
 
@@ -28,15 +26,13 @@
 
                 <span *ngFor="let navItem of currentNavItems">
                     <!-- Header -->
-                    <span igxDrawerItem igxRipple routerLinkActive="igx-nav-drawer__item--active" (click)="toggleParent('header' + navItem.name)">
-                        <button igxButton="icon" igxRipple igxRippleCentered="true" style="vertical-align: middle">
-                            <igx-icon fontSet="material">{{convertNodeStateToIcon('header' + navItem.name)}}</igx-icon>
-                        </button>
-                        <span style="vertical-align: middle">{{navItem.name}}</span>
+                    <span igxDrawerItem igxRipple routerLinkActive="igx-nav-drawer__item--active navdrawer-ellipsis" (click)="toggleParent('header' + navItem.name)">
+                        <igx-icon fontSet="material">{{convertNodeStateToIcon('header' + navItem.name)}}</igx-icon>
+                        <span class="navdrawer-ellipsis" style="vertical-align: middle">{{navItem.name}}</span>
                     </span>
                     <!-- Children -->
                     <span [id]="'header' + navItem.name" style="display:none">
-                        <span [id]="'child' + routeItem.displayName" class="innerItem" *ngFor="let routeItem of navItem.children" igxDrawerItem igxRipple
+                        <span [id]="'child' + routeItem.displayName" class="innerItem navdrawer-ellipsis" *ngFor="let routeItem of navItem.children" igxDrawerItem igxRipple
                             routerLink="{{routeItem.path}}" routerLinkActive="igx-nav-drawer__item--active">
                             {{routeItem.displayName}}
                         </span>

--- a/src/app/index/index.component.scss
+++ b/src/app/index/index.component.scss
@@ -18,8 +18,27 @@
     overflow: auto;    
 }
 
+.navdrawer-ellipsis {
+    display: inline-block;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+}
+
 .innerItem {
-    margin-left: 36px;
+    $innerMargin: 36px;
+    // The 8px here comes from the item right margin
+    $max-width-subtract: $innerMargin + 8px;
+    margin-left: $innerMargin !important;
+    max-width: calc(100% - #{$max-width-subtract});
+}
+
+:host {
+    [igxbutton="icon"] {
+        igx-icon {
+            margin-left: 0;
+        }
+    }
 }
 
 .nav-header {


### PR DESCRIPTION
Related to [indigo-theme](https://github.com/IgniteUI/igniteui-angular/pull/7617/files/09c431a259913c9329727d654b4f82188fa1392c..072a3bb304c56911df88936021e5fa6cabf2d4c8)
Fix the styles for the ellipsis and indentation of second-level items.
Remove the icon button wrapper around the item icon since it's not the click target and there is no need for it.