### PR TITLE
refactor(material-icons-extended): automate category declaration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,17 +1992,17 @@
       }
     },
     "@igniteui/material-icons-extended": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@igniteui/material-icons-extended/-/material-icons-extended-2.1.0.tgz",
-      "integrity": "sha512-fTfk9xrpcuRvU76Q33JWP0Q8wB3h/+fcd0lV3wqXzdmqujM2mcoyp1W61Npd5ghPlCHx5CdxAXLdc0T770Uufw==",
+      "version": "2.2.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@igniteui/material-icons-extended/-/material-icons-extended-2.2.0-beta.2.tgz",
+      "integrity": "sha512-p6VUNF3+AjypZTMNzrcxSPj9YhHQvVBj4fCVCz+x+yrnPapxelDkh3ECh2aVFRGJBT4wxOVee/baBBgxa33JBA==",
       "requires": {
         "@types/node": "^14.0.25"
       },
       "dependencies": {
         "@types/node": {
-          "version": "14.6.0",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.0.tgz",
-          "integrity": "sha512-mikldZQitV94akrc4sCcSjtJfsTKt4p+e/s0AGscVA6XArQ9kFclP+ZiYUMnq987rc6QlYxXv/EivqlfSLxpKA=="
+          "version": "14.6.1",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-14.6.1.tgz",
+          "integrity": "sha512-HnYlg/BRF8uC1FyKRFZwRaCPTPYKa+6I8QiUZFLredaGOou481cgFS4wKRFyKvQtX8xudqkSdBczJHIYSQYKrQ=="
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -1992,9 +1992,9 @@
       }
     },
     "@igniteui/material-icons-extended": {
-      "version": "2.2.0-beta.2",
-      "resolved": "https://registry.npmjs.org/@igniteui/material-icons-extended/-/material-icons-extended-2.2.0-beta.2.tgz",
-      "integrity": "sha512-p6VUNF3+AjypZTMNzrcxSPj9YhHQvVBj4fCVCz+x+yrnPapxelDkh3ECh2aVFRGJBT4wxOVee/baBBgxa33JBA==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@igniteui/material-icons-extended/-/material-icons-extended-2.2.0.tgz",
+      "integrity": "sha512-8uYll4SXbWKD+u+ew7wg9sBZ0BfePCjdP8G+0TU8r9qMKApvioKwUSvw/VBTPMBJ8jT+Kqb7XS+uR4gLpWS7WA==",
       "requires": {
         "@types/node": "^14.0.25"
       },

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@angular/platform-browser": "^10.0.12",
     "@angular/platform-browser-dynamic": "^10.0.12",
     "@angular/router": "^10.0.12",
-    "@igniteui/material-icons-extended": "^2.1.0",
+    "@igniteui/material-icons-extended": "^2.2.0-beta.2",
     "@types/file-saver": "^2.0.1",
     "@types/hammerjs": "^2.0.35",
     "angular-in-memory-web-api": "0.9.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@angular/platform-browser": "^10.0.12",
     "@angular/platform-browser-dynamic": "^10.0.12",
     "@angular/router": "^10.0.12",
-    "@igniteui/material-icons-extended": "^2.2.0-beta.2",
+    "@igniteui/material-icons-extended": "^2.2.0",
     "@types/file-saver": "^2.0.1",
     "@types/hammerjs": "^2.0.35",
     "angular-in-memory-web-api": "0.9.0",

--- a/src/app/data-display/icon/material-icons-extended/material-icons-extended.component.ts
+++ b/src/app/data-display/icon/material-icons-extended/material-icons-extended.component.ts
@@ -11,11 +11,7 @@ import { DOCUMENT } from "@angular/common";
 import { IgxIconService, ISelectionEventArgs } from "igniteui-angular";
 
 import {
-    finance,
-    health,
-    programming,
-    logos,
-    socialMedia,
+    all as imxIcons,
     IconCategory,
     IMXIcon
 } from "@igniteui/material-icons-extended";
@@ -38,21 +34,28 @@ export class MaterialIconsExtendedComponent implements OnInit {
     ) {}
 
     public categories: ICategoryOption[] = [
-        { text: "All", category: "all" },
-        { text: "Health", category: "health" },
-        { text: "Programming", category: "programming" },
-        { text: "Finance", category: "finance" },
-        { text: "Logos", category: "logos" },
-        { text: "Social Media", category: "social media" }
+        {
+            text: "All",
+            category: "all"
+        }
     ];
 
-    public allIcons = [
-        ...health,
-        ...programming,
-        ...finance,
-        ...logos,
-        ...socialMedia
-    ];
+    public setCategories() {
+        const categories = IconCategory.values().map(
+            (category) =>
+                ({
+                    text: category
+                        .split(" ")
+                        .map((w) => w.replace(/^\w/, (c) => c.toUpperCase()))
+                        .join(" "),
+                    category
+                } as ICategoryOption)
+        );
+
+        this.categories = [...this.categories, ...categories];
+    }
+
+    public allIcons = imxIcons;
 
     public selectedCategory: IconCategory | "all" = "all";
 
@@ -65,8 +68,12 @@ export class MaterialIconsExtendedComponent implements OnInit {
     }
 
     addIcons() {
-        for (const icon of this.allIcons) {
-            this.iconService.addSvgIconFromText(icon.name, icon.value, "imx-icons");
+        for (const icon of imxIcons) {
+            this.iconService.addSvgIconFromText(
+                icon.name,
+                icon.value,
+                "imx-icons"
+            );
         }
     }
 
@@ -92,17 +99,24 @@ export class MaterialIconsExtendedComponent implements OnInit {
         this.renderer.removeChild(this.document.body, tempField);
 
         if (element.innerText !== "done") {
-            this.renderer.setProperty(element, 'innerText', 'done');
-            this.renderer.addClass(target, "sample__grid-item-clipboard--success");
+            this.renderer.setProperty(element, "innerText", "done");
+            this.renderer.addClass(
+                target,
+                "sample__grid-item-clipboard--success"
+            );
 
             setTimeout(() => {
-                this.renderer.setProperty(element, 'innerText', 'content_copy');
-                this.renderer.removeClass(target, "sample__grid-item-clipboard--success");
+                this.renderer.setProperty(element, "innerText", "content_copy");
+                this.renderer.removeClass(
+                    target,
+                    "sample__grid-item-clipboard--success"
+                );
             }, 1500);
         }
     }
 
     ngOnInit() {
+        this.setCategories();
         this.addIcons();
     }
 }


### PR DESCRIPTION
Refactor the sample so that newly added categories are automatically added when a new version of the package is installed.