### PR TITLE
fix(grid): Changing the dataType of the column components. #2358

### DIFF
--- a/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.html
+++ b/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.html
@@ -3,9 +3,9 @@
         [paging]="true" [height]="'530px'" width="100%">
         <igx-column field='ContactName' width="20%"></igx-column>
         <igx-column field='Country' width="20%"></igx-column>
-        <igx-column field='City' width="20%" dataType="number"></igx-column>
-        <igx-column field='PostalCode' width="20%" dataType="number"></igx-column>
-        <igx-column field='CompanyName' width="20%" dataType="number"></igx-column>
+        <igx-column field='City' width="20%" dataType="string"></igx-column>
+        <igx-column field='PostalCode' width="20%" dataType="string"></igx-column>
+        <igx-column field='CompanyName' width="20%" dataType="string"></igx-column>
 
         <ng-template igxHeadSelector>
             <div class="header-selector">

--- a/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.html
+++ b/src/app/grid/grid-sample-selection-template-numbers/grid-sample-selection-template-numbers.component.html
@@ -3,9 +3,9 @@
         [paging]="true" [height]="'530px'" width="100%">
         <igx-column field='ContactName' width="20%"></igx-column>
         <igx-column field='Country' width="20%"></igx-column>
-        <igx-column field='City' width="20%" dataType="string"></igx-column>
-        <igx-column field='PostalCode' width="20%" dataType="string"></igx-column>
-        <igx-column field='CompanyName' width="20%" dataType="string"></igx-column>
+        <igx-column field='City' width="20%"></igx-column>
+        <igx-column field='PostalCode' width="20%"></igx-column>
+        <igx-column field='CompanyName' width="20%"></igx-column>
 
         <ng-template igxHeadSelector>
             <div class="header-selector">


### PR DESCRIPTION
Closes #2358 
The `dataType` of the `City`, `PostalCode` and `CompanyName` columns was set to number which was causing the data piped into these columns to be treated as number by the decimalPipe.