### PR TITLE
do nothing if dragged row and targeted row are same

### DIFF
--- a/src/app/tree-grid/tree-grid-row-reorder/tree-grid-row-reorder.component.ts
+++ b/src/app/tree-grid/tree-grid-row-reorder/tree-grid-row-reorder.component.ts
@@ -34,6 +34,12 @@ export class TreeGridRowReorderComponent {
     private moveRow(draggedRow: IgxTreeGridRowComponent, cursorPosition: Point): void {
         const row: IgxTreeGridRowComponent = this.catchCursorPosOnElem(this.treeGrid.rowList.toArray(), cursorPosition);
         if (!row) { return; }
+
+        if (row.rowData.ID === draggedRow.rowData.ID) {
+            /** dragged row and targeted row are same */
+            return;
+        }
+
         if (row.rowData.ParentID === -1) {
             this.performDrop(draggedRow, row).ParentID = -1;
         } else {


### PR DESCRIPTION
# Description

In `Tree Grid reorder`, do nothing if dragged row and targeted row are same (drag and drop in same row).

Same result when drag and drop in out of `Grid`.