### PR TITLE
changing regex to match " as well for fonts

### DIFF
--- a/projects/app-lob/src/app/app.component.ts
+++ b/projects/app-lob/src/app/app.component.ts
@@ -42,7 +42,7 @@ export class AppComponent implements OnInit {
         if (e.origin === e.data.origin && typeof e.data.themeStyle === 'string') {
             this.styleElem.textContent = e.data.themeStyle;
 
-            const typeface = window.getComputedStyle(this.document.body).fontFamily.replace(/\'/g, '');
+            const typeface = window.getComputedStyle(this.document.body).fontFamily.replace(/[\'\"]/g, '');
             if (!(typeface.match(/,/g) || []).length &&
                 !this.typefacesLoaded.includes(typeface)) {
                 this.typefacesLoaded.push(typeface);

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -25,7 +25,7 @@ export class AppComponent implements OnInit {
     private onMessage(e: MessageEvent) {
         if (e.origin === e.data.origin && typeof e.data.themeStyle === 'string') {
             this.styleElem.textContent = e.data.themeStyle;
-            const typeface = window.getComputedStyle(this.document.body).fontFamily.replace(/\'/g, '');
+            const typeface = window.getComputedStyle(this.document.body).fontFamily.replace(/[\'\"]/g, '');
             if (!(typeface.match(/,/g) || []).length &&
                 !this.typefacesLoaded.includes(typeface)) {
                 this.typefacesLoaded.push(typeface);


### PR DESCRIPTION
The Indigo themes don't apply fonts because Nunito Sans is obtained like this: `"Nunito Sans"` which leaves the quotations intact for the google-apis link 