### PR TITLE
Change assets regex to handle relative paths

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -65,7 +65,7 @@ gulp.task("watch-live-editing", gulp.series("generate-live-editing", () => {
 const excludedDirectories = ["index", "assets", "environment"];
 
 const getSampleNameFromFileName = (fileName, sampleBaseDir) => fileName.replace(sampleBaseDir + "--", "");
-var assetsRegex = new RegExp("\/?assets\/", "g");
+var assetsRegex = new RegExp(/([\.]{0,2}\/)*assets\//g);
 
 const processApp = (projectPath, dest, directoriesToExclude) => {
     if(!fs.existsSync(submodule)) {


### PR DESCRIPTION
Closes #2686 

This PR should be tested on staging environment, since the wrongly replaced URL segments are applied on build 