### PR TITLE
Disable ssource Map

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -29,7 +29,7 @@
                         "buildOptimizer": false,
                         "optimization": false,
                         "namedChunks": true,
-                        "sourceMap": true,
+                        "sourceMap": false,
                         "progress": true
                     },
                     "configurations": {


### PR DESCRIPTION
With source map, performance is worse and also some erros occur after compile:

![MicrosoftTeams-image (27)](https://user-images.githubusercontent.com/14248932/134672701-0f48a2c4-6a96-4ff9-8de6-cb3a808e0770.png)


