### PR TITLE
Refactor row actions samples

### DIFF
--- a/src/app/grid/grid-action-strip/grid-action-strip-sample.html
+++ b/src/app/grid/grid-action-strip/grid-action-strip-sample.html
@@ -1,46 +1,43 @@
 <div class="grid__wrapper">
-    <igx-grid igxPreventDocumentScroll #gridRowEditTransaction [batchEditing]="true" [data]="data" width="100%"
-        height="500px" [rowEditable]="true" [allowFiltering]="true" (onDataPreLoad)="actionstrip.hide()">
+    <igx-grid igxPreventDocumentScroll #grid [data]="data" [primaryKey]="'ProductID'" width="100%"
+        height="500px" [rowEditable]="true" [batchEditing]="true" [allowFiltering]="true">
         <igx-column field="ProductID" header="Product ID" [pinned]="true" [hidden]='true' [filterable]="false">
         </igx-column>
-        <igx-column field="ProductName" header="Product Name" [dataType]="'string'" [sortable]="true"></igx-column>
-        <igx-column field="UnitPrice" header="Unit Price" [dataType]="'string'" [sortable]="true"></igx-column>
+        <igx-column field="ProductName" header="Product Name" dataType="string" [sortable]="true"></igx-column>
+        <igx-column field="UnitPrice" header="Unit Price" dataType="currency" [sortable]="true"></igx-column>
         <igx-column field="UnitsOnOrder" header="Units On Order" dataType="number" [editable]="false"
             [filterable]="false"></igx-column>
-        <igx-column field="UnitsInStock" header="Units In Stock" dataType="number" [sortable]="true">
-            <ng-template igxCellEditor let-cell="cell">
-                <input name="units" [igxFocus]="true" [(ngModel)]="cell.editValue"
-                    style="color: black; width: 30px;" />
-            </ng-template>
-        </igx-column>
-        <igx-column field="QuantityPerUnit" header="Quantity Per Unit" [dataType]="'string'" [filterable]="false">
+        <igx-column field="UnitsInStock" header="Units In Stock" dataType="number" [sortable]="true"></igx-column>
+        <igx-column field="QuantityPerUnit" header="Quantity Per Unit" dataType="string" [filterable]="false">
         </igx-column>
         <igx-column field="ReorderLevel" header="Reorder Level" dataType="number" [filterable]="false"></igx-column>
-        <igx-column field="Discontinued" header="Discontinued" [dataType]="'boolean'" [filterable]="false">
+        <igx-column field="Discontinued" header="Discontinued" dataType="boolean" [filterable]="false">
         </igx-column>
         <igx-action-strip #actionstrip>
             <igx-grid-pinning-actions></igx-grid-pinning-actions>
-            <button title="Edit" igxButton="icon" igxRipple 
-                (click)='startEdit(actionstrip.context)'>
-                <igx-icon>edit</igx-icon>
-            </button>
-            <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='undo(actionstrip.context)'>
-                <igx-icon>undo</igx-icon>
-            </button>
-            <button title="Redo All" igxButton="icon" igxRipple
-                *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
-                (click)='redo(actionstrip.context)'>
-                <igx-icon>redo</igx-icon>
-            </button>
-            <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='commit(actionstrip.context)'>
-                <igx-icon>save</igx-icon>
-            </button>
-            <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
-                (click)='actionstrip.context.delete()'>
-                <igx-icon>delete</igx-icon>
-            </button>
+            <ng-container *ngIf="!inEditMode(actionstrip.context)">
+                <button title="Edit" igxButton="icon" igxRipple
+                    (click)='startEdit(actionstrip.context)'>
+                    <igx-icon>edit</igx-icon>
+                </button>
+                <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='undo(actionstrip.context)'>
+                    <igx-icon>undo</igx-icon>
+                </button>
+                <button title="Redo All" igxButton="icon" igxRipple
+                    *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
+                    (click)='redo(actionstrip.context)'>
+                    <igx-icon>redo</igx-icon>
+                </button>
+                <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='commit(actionstrip.context)'>
+                    <igx-icon>save</igx-icon>
+                </button>
+                <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
+                    (click)='actionstrip.context.delete()'>
+                    <igx-icon>delete</igx-icon>
+                </button>
+            </ng-container>
         </igx-action-strip>
     </igx-grid>
 </div>

--- a/src/app/grid/grid-action-strip/grid-action-strip-sample.scss
+++ b/src/app/grid/grid-action-strip/grid-action-strip-sample.scss
@@ -1,9 +1,3 @@
 .grid__wrapper {
     margin: 15px;
 }
-
-h4 {
-    text-align: center;
-    padding-top: 2%;
-    padding-bottom: 2%;
-}

--- a/src/app/grid/grid-action-strip/grid-action-strip-sample.ts
+++ b/src/app/grid/grid-action-strip/grid-action-strip-sample.ts
@@ -18,7 +18,7 @@ export class GridActionStripSampleComponent {
     }
 
     public isDirty(rowContext: RowType) {
-        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext?.key);
         return rowContext && (rowContext.deleted || isRowEdited);
     }
 

--- a/src/app/grid/grid-action-strip/grid-action-strip-sample.ts
+++ b/src/app/grid/grid-action-strip/grid-action-strip-sample.ts
@@ -8,9 +8,7 @@ import { DATA } from '../../data/nwindData';
     templateUrl: 'grid-action-strip-sample.html'
 })
 export class GridActionStripSampleComponent {
-    @ViewChild('gridRowEditTransaction', { read: IgxGridComponent, static: true }) public grid: IgxGridComponent;
-
-    public currentActiveGrid: { id: string; transactions: any[] } = { id: '', transactions: [] };
+    @ViewChild('grid', { read: IgxGridComponent, static: true }) public grid: IgxGridComponent;
 
     public data: any[];
     public discardedTransactionsPerRecord: Map<number, Transaction[]> = new Map<number, Transaction[]>();
@@ -19,31 +17,27 @@ export class GridActionStripSampleComponent {
         this.data = DATA;
     }
 
-    public stateFormatter(value: string) {
-        return JSON.stringify(value);
-    }
-
-    public typeFormatter(value: string) {
-        return value.toUpperCase();
-    }
-
     public isDirty(rowContext: RowType) {
-        return rowContext && rowContext.deleted;
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        return rowContext && (rowContext.deleted || isRowEdited);
     }
 
     public isDeleted(rowContext: RowType) {
         return rowContext && rowContext.deleted;
     }
 
-    public startEdit(row?): void {
-        const firstEditable = row.cells.filter(cell => cell.editable)[0];
-        const grid = row.grid;
+    public inEditMode(rowContext: RowType) {
+        return rowContext && rowContext.inEditMode;
+    }
 
-        if (grid.rowList.filter(r => r === row).length !== 0) {
-            grid.gridAPI.crudService.enterEditMode(firstEditable, event);
-            firstEditable.activate();
+    public startEdit(rowContext: RowType): void {
+        const firstEditable = rowContext.cells.filter(cell => cell.editable)[0];
+        const grid = rowContext.grid;
+
+        if (grid.rowList.filter(r => r === rowContext).length !== 0) {
+            grid.gridAPI.crudService.enterEditMode(firstEditable);
+            firstEditable.activate(null);
         }
-        row.hide();
     }
 
     public commit(rowContext: RowType) {

--- a/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.html
+++ b/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.html
@@ -1,6 +1,6 @@
 <div class="grid__wrapper">
-    <igx-hierarchical-grid igxPreventDocumentScroll  class="hgrid" [data]="data"
-        [height]="'500px'" [width]="'100%'" [rowEditable]="true" [allowFiltering]="true" #hierarchicalGrid>
+    <igx-hierarchical-grid igxPreventDocumentScroll #hierarchicalGrid [data]="data" [primaryKey]="'ID'"
+        [height]="'500px'" [width]="'100%'" [rowEditable]="true" [batchEditing]="true" [allowFiltering]="true">
             <igx-column field="Artist" [sortable]="true" [disableHiding]="true" [width]="'200px'"></igx-column>
             <igx-column field="Photo" [width]="'200px'">
                 <ng-template igxCell let-cell="cell">
@@ -9,52 +9,54 @@
                     </div>
                 </ng-template>
             </igx-column>
-            <igx-column field="Debut" [sortable]="true" [width]="'200px'" [formatter]="formatter"></igx-column>
-            <igx-column field="GrammyNominations" header="Grammy Nominations" [sortable]="true" dataType="number" [width]="'200px'"></igx-column>
-            <igx-column field="GrammyAwards" header="Grammy Awards" [sortable]="true" dataType="number" [width]="'200px'"></igx-column>
+            <igx-column field="Debut" dataType="number" [sortable]="true" [width]="'200px'" [formatter]="formatter"></igx-column>
+            <igx-column field="GrammyNominations" header="Grammy Nominations" dataType="number" [sortable]="true" [width]="'200px'"></igx-column>
+            <igx-column field="GrammyAwards" header="Grammy Awards" dataType="number" [sortable]="true" [width]="'200px'"></igx-column>
 
             <igx-row-island [height]="null" [key]="'Albums'" [autoGenerate]="false">
-                <igx-column field="Album" [sortable]="true"></igx-column>
-                <igx-column field="LaunchDate" header="Launch Date" [sortable]="true" [dataType]="'date'"></igx-column>
-                <igx-column field="BillboardReview" header="Billboard Review" [sortable]="true"></igx-column>
-                <igx-column field="USBillboard200" header="US Billboard 200" [sortable]="true"></igx-column>
+                <igx-column field="Album" dataType="string" [sortable]="true"></igx-column>
+                <igx-column field="LaunchDate" header="Launch Date" dataType="date" [sortable]="true"></igx-column>
+                <igx-column field="BillboardReview" header="Billboard Review" dataType="number" [sortable]="true"></igx-column>
+                <igx-column field="USBillboard200" header="US Billboard 200" dataType="number" [sortable]="true"></igx-column>
             <igx-row-island [height]="null" [key]="'Songs'" [autoGenerate]="false">
-                    <igx-column field="Number" header="No."></igx-column>
-                    <igx-column field="Title"></igx-column>
+                    <igx-column field="Number" header="No." dataType="number"></igx-column>
+                    <igx-column field="Title" dataType="string"></igx-column>
                     <igx-column field="Released" dataType="date"></igx-column>
-                    <igx-column field="Genre"></igx-column>
+                    <igx-column field="Genre" dataType="string"></igx-column>
             </igx-row-island>
         </igx-row-island>
 
         <igx-row-island [height]="null" [key]="'Tours'" [autoGenerate]="false">
-            <igx-column field="Tour"></igx-column>
-            <igx-column field="StartedOn" header="Started on"></igx-column>
-            <igx-column field="Location"></igx-column>
-            <igx-column field="Headliner"></igx-column>
+            <igx-column field="Tour" dataType="string"></igx-column>
+            <igx-column field="StartedOn" header="Started on" dataType="string"></igx-column>
+            <igx-column field="Location" dataType="string"></igx-column>
+            <igx-column field="Headliner" dataType="string"></igx-column>
         </igx-row-island>
         <igx-action-strip #actionstrip>
             <igx-grid-pinning-actions></igx-grid-pinning-actions>
-            <button title="Edit" igxButton="icon" igxRipple 
-                (click)='startEdit(actionstrip.context)'>
-                <igx-icon>edit</igx-icon>
-            </button>
-            <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='undo(actionstrip.context)'>
-                <igx-icon>undo</igx-icon>
-            </button>
-            <button title="Redo All" igxButton="icon" igxRipple
-                *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
-                (click)='redo(actionstrip.context)'>
-                <igx-icon>redo</igx-icon>
-            </button>
-            <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='commit(actionstrip.context)'>
-                <igx-icon>save</igx-icon>
-            </button>
-            <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
-                (click)='actionstrip.context.delete()'>
-                <igx-icon>delete</igx-icon>
-            </button>
+            <ng-container *ngIf="!inEditMode(actionstrip.context)">
+                <button title="Edit" igxButton="icon" igxRipple
+                    (click)='startEdit(actionstrip.context)'>
+                    <igx-icon>edit</igx-icon>
+                </button>
+                <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='undo(actionstrip.context)'>
+                    <igx-icon>undo</igx-icon>
+                </button>
+                <button title="Redo All" igxButton="icon" igxRipple
+                    *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
+                    (click)='redo(actionstrip.context)'>
+                    <igx-icon>redo</igx-icon>
+                </button>
+                <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='commit(actionstrip.context)'>
+                    <igx-icon>save</igx-icon>
+                </button>
+                <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
+                    (click)='actionstrip.context.delete()'>
+                    <igx-icon>delete</igx-icon>
+                </button>
+            </ng-container>
         </igx-action-strip>
-        </igx-hierarchical-grid>
+    </igx-hierarchical-grid>
 </div>

--- a/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.scss
+++ b/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.scss
@@ -2,8 +2,11 @@
     margin: 15px;
 }
 
-h4 {
-    text-align: center;
-    padding-top: 2%;
-    padding-bottom: 2%;
+.photo {
+    vertical-align: middle;
+    max-height: 62px;
+}
+
+.cell__inner_2 {
+    margin: 1px
 }

--- a/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.ts
+++ b/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.ts
@@ -29,7 +29,7 @@ export class HGridActionStripSampleComponent implements AfterViewInit{
     public formatter = (a) => a;
 
     public isDirty(rowContext: RowType) {
-        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext?.key);
         return rowContext && (rowContext.deleted || isRowEdited);
     }
 

--- a/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.ts
+++ b/src/app/hierarchical-grid/hierarchical-grid-action-strip/hierarchical-grid-action-strip-sample.ts
@@ -8,13 +8,11 @@ import { SINGERS } from '../../data/singersData';
     templateUrl: 'hierarchical-grid-action-strip-sample.html'
 })
 export class HGridActionStripSampleComponent implements AfterViewInit{
-    @ViewChild('hierarchicalGrid', { read: IgxHierarchicalGridComponent, static: true }) 
+    @ViewChild('hierarchicalGrid', { read: IgxHierarchicalGridComponent, static: true })
     public grid: IgxHierarchicalGridComponent;
 
     @ViewChildren(IgxColumnComponent, { read: IgxColumnComponent })
     public columns: QueryList<IgxColumnComponent>;
-
-    public currentActiveGrid: { id: string; transactions: any[] } = { id: '', transactions: [] };
 
     public data: any[];
     public discardedTransactionsPerRecord: Map<number, Transaction[]> = new Map<number, Transaction[]>();
@@ -30,31 +28,27 @@ export class HGridActionStripSampleComponent implements AfterViewInit{
 
     public formatter = (a) => a;
 
-    public stateFormatter(value: string) {
-        return JSON.stringify(value);
-    }
-
-    public typeFormatter(value: string) {
-        return value.toUpperCase();
-    }
-
     public isDirty(rowContext: RowType) {
-        return rowContext && rowContext.deleted;
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        return rowContext && (rowContext.deleted || isRowEdited);
     }
 
     public isDeleted(rowContext: RowType) {
         return rowContext && rowContext.deleted;
     }
 
-    public startEdit(row?): void {
-        const firstEditable = row.cells.filter(cell => cell.editable)[0];
-        const grid = row.grid;
+    public inEditMode(rowContext: RowType) {
+        return rowContext && rowContext.inEditMode;
+    }
 
-        if (grid.rowList.filter(r => r === row).length !== 0) {
-            grid.gridAPI.crudService.enterEditMode(firstEditable, event);
-            firstEditable.activate();
+    public startEdit(rowContext: RowType): void {
+        const firstEditable = rowContext.cells.filter(cell => cell.editable)[0];
+        const grid = rowContext.grid;
+
+        if (grid.rowList.filter(r => r === rowContext).length !== 0) {
+            grid.gridAPI.crudService.enterEditMode(firstEditable);
+            firstEditable.activate(null);
         }
-        row.hide();
     }
 
     public commit(rowContext: RowType) {

--- a/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.html
+++ b/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.html
@@ -1,40 +1,42 @@
 <div class="grid__wrapper">
-    <igx-tree-grid igxPreventDocumentScroll [batchEditing]="true" [data]="data" primaryKey="ID" foreignKey="ParentID"  width="100%"
-        height="500px" [rowEditable]="true" [allowFiltering]="true" >
+    <igx-tree-grid igxPreventDocumentScroll #treeGrid [data]="data" primaryKey="ID" foreignKey="ParentID" width="100%"
+        height="500px" [rowEditable]="true" [batchEditing]="true" [allowFiltering]="true">
         <igx-column [field]="'Name'" dataType="string" [sortable]="true" [disableHiding]="true"></igx-column>
-            <igx-column [field]="'ID'" dataType="number" [sortable]="true"></igx-column>
-            <igx-column [field]="'Title'" dataType="string" [sortable]="true" [disableHiding]="true"></igx-column>
-            <igx-column [field]="'HireDate'" dataType="date" [sortable]="true" [hidden]="true"></igx-column>
-            <igx-column [field]="'Age'" dataType="number" [sortable]="true" [hidden]="true"></igx-column>
-            <igx-column [field]="'Address'" dataType="string" [sortable]="true"></igx-column>
-            <igx-column [field]="'City'" dataType="string" [sortable]="true"></igx-column>
-            <igx-column [field]="'Country'" dataType="string" [sortable]="true"></igx-column>
-            <igx-column [field]="'Fax'" dataType="string" [sortable]="true"></igx-column>
-            <igx-column [field]="'PostalCode'" dataType="string" [sortable]="true"></igx-column>
-            <igx-column [field]="'Phone'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'ID'" dataType="number" [sortable]="true"></igx-column>
+        <igx-column [field]="'Title'" dataType="string" [sortable]="true" [disableHiding]="true"></igx-column>
+        <igx-column [field]="'HireDate'" dataType="date" [sortable]="true" [hidden]="true"></igx-column>
+        <igx-column [field]="'Age'" dataType="number" [sortable]="true" [hidden]="true"></igx-column>
+        <igx-column [field]="'Address'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'City'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'Country'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'Fax'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'PostalCode'" dataType="string" [sortable]="true"></igx-column>
+        <igx-column [field]="'Phone'" dataType="string" [sortable]="true"></igx-column>
         <igx-action-strip #actionstrip>
             <igx-grid-pinning-actions></igx-grid-pinning-actions>
-            <button title="Edit" igxButton="icon" igxRipple 
-                (click)='startEdit(actionstrip.context)'>
-                <igx-icon>edit</igx-icon>
-            </button>
-            <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='undo(actionstrip.context)'>
-                <igx-icon>undo</igx-icon>
-            </button>
-            <button title="Redo All" igxButton="icon" igxRipple
-                *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
-                (click)='redo(actionstrip.context)'>
-                <igx-icon>redo</igx-icon>
-            </button>
-            <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
-                (click)='commit(actionstrip.context)'>
-                <igx-icon>save</igx-icon>
-            </button>
-            <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
-                (click)='actionstrip.context.delete()'>
-                <igx-icon>delete</igx-icon>
-            </button>
+            <ng-container *ngIf="!inEditMode(actionstrip.context)">
+                <button title="Edit" igxButton="icon" igxRipple
+                    (click)='startEdit(actionstrip.context)'>
+                    <igx-icon>edit</igx-icon>
+                </button>
+                <button title="Undo All" igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='undo(actionstrip.context)'>
+                    <igx-icon>undo</igx-icon>
+                </button>
+                <button title="Redo All" igxButton="icon" igxRipple
+                    *ngIf='!isDirty(actionstrip.context) && hasDiscardedTransactions(actionstrip.context)'
+                    (click)='redo(actionstrip.context)'>
+                    <igx-icon>redo</igx-icon>
+                </button>
+                <button title='Saveeeeeeee' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                    (click)='commit(actionstrip.context)'>
+                    <igx-icon>save</igx-icon>
+                </button>
+                <button title="Delete" igxButton="icon" igxRipple *ngIf='!isDeleted(actionstrip.context)'
+                    (click)='actionstrip.context.delete()'>
+                    <igx-icon>delete</igx-icon>
+                </button>
+            </ng-container>
         </igx-action-strip>
     </igx-tree-grid>
 </div>

--- a/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.html
+++ b/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.html
@@ -28,7 +28,7 @@
                     (click)='redo(actionstrip.context)'>
                     <igx-icon>redo</igx-icon>
                 </button>
-                <button title='Saveeeeeeee' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
+                <button title='Save' igxButton="icon" igxRipple *ngIf='isDirty(actionstrip.context)'
                     (click)='commit(actionstrip.context)'>
                     <igx-icon>save</igx-icon>
                 </button>

--- a/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.scss
+++ b/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.scss
@@ -1,9 +1,3 @@
 .grid__wrapper {
     margin: 15px;
 }
-
-h4 {
-    text-align: center;
-    padding-top: 2%;
-    padding-bottom: 2%;
-}

--- a/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.ts
+++ b/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.ts
@@ -7,45 +7,37 @@ import { generateEmployeeDetailedFlatData } from '../data/employees-flat-detaile
     styleUrls: [`tree-grid-action-strip-sample.scss`],
     templateUrl: 'tree-grid-action-strip-sample.html'
 })
-export class TreeGridActionStripSampleComponent implements OnInit {
-    @ViewChild('gridRowEditTransaction', { read: IgxTreeGridComponent, static: true }) public grid: IgxTreeGridComponent;
-
-    public currentActiveGrid: { id: string; transactions: any[] } = { id: '', transactions: [] };
+export class TreeGridActionStripSampleComponent {
+    @ViewChild('treeGrid', { read: IgxTreeGridComponent, static: true }) public grid: IgxTreeGridComponent;
 
     public data: any[];
     public discardedTransactionsPerRecord: Map<number, Transaction[]> = new Map<number, Transaction[]>();
 
-    constructor() { }
-
-    public ngOnInit() {
+    constructor() {
         this.data = generateEmployeeDetailedFlatData();
     }
 
-    public stateFormatter(value: string) {
-        return JSON.stringify(value);
-    }
-
-    public typeFormatter(value: string) {
-        return value.toUpperCase();
-    }
-
     public isDirty(rowContext: RowType) {
-        return rowContext && rowContext.deleted;
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        return rowContext && (rowContext.deleted || isRowEdited);
     }
 
     public isDeleted(rowContext: RowType) {
         return rowContext && rowContext.deleted;
     }
 
-    public startEdit(row?): void {
-        const firstEditable = row.cells.filter(cell => cell.editable)[0];
-        const grid = row.grid;
+    public inEditMode(rowContext: RowType) {
+        return rowContext && rowContext.inEditMode;
+    }
 
-        if (grid.rowList.filter(r => r === row).length !== 0) {
-            grid.gridAPI.crudService.enterEditMode(firstEditable, event);
-            firstEditable.activate();
+    public startEdit(rowContext: RowType): void {
+        const firstEditable = rowContext.cells.filter(cell => cell.editable)[0];
+        const grid = rowContext.grid;
+
+        if (grid.rowList.filter(r => r === rowContext).length !== 0) {
+            grid.gridAPI.crudService.enterEditMode(firstEditable);
+            firstEditable.activate(null);
         }
-        row.hide();
     }
 
     public commit(rowContext: RowType) {

--- a/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.ts
+++ b/src/app/tree-grid/tree-grid-action-strip/tree-grid-action-strip-sample.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { IgxTreeGridComponent, RowType, Transaction } from 'igniteui-angular';
 import { generateEmployeeDetailedFlatData } from '../data/employees-flat-detailed';
 
@@ -18,7 +18,7 @@ export class TreeGridActionStripSampleComponent {
     }
 
     public isDirty(rowContext: RowType) {
-        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext.key);
+        const isRowEdited = this.grid.transactions.getAggregatedChanges(true).find(x => x.id === rowContext?.key);
         return rowContext && (rowContext.deleted || isRowEdited);
     }
 


### PR DESCRIPTION
Closes #3014 

#### Issue-related changes:
1. Grid
   - in html file - add **primaryKey**
   - in ts file - changes in **startEdit** method
2. Hierarchical Grid
    - the same as the Grid 
3. Tree Grid
    - in html file - add a reference to the tree-grid, i.e., **#treeGrid**
    - in ts file - same as the above two

#### Sample-related changes:
1. Add **ng-container** with ***ngIf** check to hide action strip custom buttons when editing
2. Changes in **isDirty** method to show 'Undo All', 'Redo All' and 'Save' icons properly

#### Refactoring-related changes:
1. Removed styling for missing **h4 tag**, added missing styling for classes used for **Photo** column in hGrid sample
2. Removed unused methods and properties, like **stateFormatter**, **typeFormatter**, etc.
3. Changed how the **dataType** property is set (some are set with square brackets and others without square brackets) and added dataType property to the columns that do not have it.