### PR TITLE
fix(combo): remove duplicate igx-combo in template sample

### DIFF
--- a/src/app/lists/combo/combo-template/combo-template.component.html
+++ b/src/app/lists/combo/combo-template/combo-template.component.html
@@ -32,9 +32,7 @@
         <igx-icon>cancel</igx-icon>
     </ng-template>
 
-    <igx-combo>
-        <ng-template igxComboEmpty>
-            <span class="empty-class">No available states</span>
-        </ng-template>
-    </igx-combo>
+    <ng-template igxComboEmpty>
+        <span class="empty-class">No available states</span>
+    </ng-template>
 </igx-combo>


### PR DESCRIPTION
PS: Those could also be optimized with the short template syntax `*igxComboEmpty` to reduce the ng-template bulk if it's not needed:
```html
<span *igxComboEmpty class="empty-class">No available states</span>
```