### PR TITLE
fix(overlay): use correct attach method and apply styles properly

### DIFF
--- a/src/app/interactions/overlay/overlay-dynamic-card/overlay-dynamic-card.component.html
+++ b/src/app/interactions/overlay/overlay-dynamic-card/overlay-dynamic-card.component.html
@@ -1,11 +1,11 @@
 <div class="card-wrapper">
     <igx-card>
       <igx-card-header>
-        <h3 class="igx-card-header__title">Brad Stanley</h3>
-        <h5 class="igx-card-header__subtitle">Audi AG</h5>
+        <h3 igxCardHeaderTitle>Brad Stanley</h3>
+        <h5 igxCardHeaderSubtitle>Audi AG</h5>
       </igx-card-header>
       <igx-card-content>
-        <p class="igx-card-content__text">Brad Stanley (born 17 March 1963 in Titting, Germany) is a German business executive and chairman of the Vorstand (CEO) of Audi AG.</p>
+        <p>Brad Stanley (born 17 March 1963 in Titting, Germany) is a German business executive and chairman of the Vorstand (CEO) of Audi AG.</p>
       </igx-card-content>
     </igx-card>
-  </div>
+</div>

--- a/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.html
+++ b/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <button class="igx-button--raised" #buttonElement igxButton (click)='showOverlay()'>
+    <button class="button" #buttonElement igxButton="raised" (click)="showOverlay()">
         Show Card
     </button>
 </div>

--- a/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.scss
+++ b/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.scss
@@ -1,8 +1,8 @@
 .content {
     width: 100%;
     height: 100%;
-} 
-button {
+}
+.button {
     margin-top: 10%;
     margin-left: 45%;
     width: 160px;

--- a/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.ts
+++ b/src/app/interactions/overlay/overlay-main-1/overlay-main-sample-1.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnDestroy } from '@angular/core';
+import { Component, Inject, OnDestroy, ViewContainerRef } from '@angular/core';
 import { IgxOverlayService } from 'igniteui-angular';
 import { MyDynamicCardComponent} from '../overlay-dynamic-card/overlay-dynamic-card.component';
 @Component({
@@ -9,11 +9,14 @@ import { MyDynamicCardComponent} from '../overlay-dynamic-card/overlay-dynamic-c
 export class OverlaySampleMain1Component implements OnDestroy {
     private _overlayId: string;
 
-    constructor(@Inject(IgxOverlayService) public overlayService: IgxOverlayService) {}
+    constructor(
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public showOverlay() {
         if (!this._overlayId) {
-            this._overlayId = this.overlayService.attach(MyDynamicCardComponent);
+            this._overlayId = this.overlayService.attach(MyDynamicCardComponent, this.viewContainerRef);
         }
 
         this.overlayService.show(this._overlayId);

--- a/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.html
+++ b/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <button class="igx-button--raised" #buttonElement igxButton (click)='toggleOverlay()'>
+    <button class="button" #buttonElement igxButton="raised" (click)="toggleOverlay()">
         Toggle Card
     </button>
 </div>

--- a/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.scss
+++ b/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.scss
@@ -1,8 +1,8 @@
 .content {
     width: 100%;
     height: 100%;
-} 
-button {
+}
+.button {
     margin-top: 10%;
     margin-left: 45%;
     width: 160px;

--- a/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.ts
+++ b/src/app/interactions/overlay/overlay-main-2/overlay-main-sample-2.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
 import { ConnectedPositioningStrategy, IgxOverlayService } from 'igniteui-angular';
 import { CardSample1Component } from '../../../layouts/card/card-sample-1/card-sample-1.component';
 // tslint:disable:object-literal-sort-keys
@@ -16,13 +16,15 @@ export class OverlaySampleMain2Component implements OnDestroy {
 
 
     constructor(
-        @Inject(IgxOverlayService) public overlayService: IgxOverlayService) {}
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public toggleOverlay() {
         if (this._cardHidden) {
             if (!this._overlayId) {
                 const positionStrategy = new ConnectedPositioningStrategy();
-                this._overlayId = this.overlayService.attach(CardSample1Component, {
+                this._overlayId = this.overlayService.attach(CardSample1Component, this.viewContainerRef, {
                     target: this.buttonElement.nativeElement,
                     positionStrategy,
                     modal: false,

--- a/src/app/interactions/overlay/overlay-main-3/overlay-main-sample-3.component.html
+++ b/src/app/interactions/overlay/overlay-main-3/overlay-main-sample-3.component.html
@@ -1,5 +1,5 @@
 <div class="container-div">
-    <button #buttonElement igxButton (click)='showOverlay()'>
+    <button #buttonElement igxButton (click)="showOverlay()">
         Show Card
     </button>
     <app-igx-card-simple #card class="card"></app-igx-card-simple>

--- a/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.html
+++ b/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <button class="igx-button--raised" #buttonElement igxButton (click)='showOverlay()'>
+    <button class="button" #buttonElement igxButton="raised" (click)="showOverlay()">
         Show Card
     </button>
 </div>

--- a/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.scss
+++ b/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.scss
@@ -2,7 +2,7 @@
     width: 100%;
     height: 100%;
 }
-button {
+.button {
     margin-top: 10%;
     margin-left: calc(50% - 80px);
     width: 160px;

--- a/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.ts
+++ b/src/app/interactions/overlay/overlay-positioning-1/overlay-position-sample-1.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
 import { ConnectedPositioningStrategy, IgxOverlayService, OverlaySettings } from 'igniteui-angular';
 import { Subject } from 'rxjs';
 import { MyDynamicCardComponent } from '../overlay-dynamic-card/overlay-dynamic-card.component';
@@ -13,7 +13,10 @@ export class OverlayPositionSample1Component implements OnDestroy {
     private buttonElement: ElementRef;
     private _overlayId: string;
 
-    constructor(@Inject(IgxOverlayService) public overlayService: IgxOverlayService) { }
+    constructor(
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public showOverlay() {
         if (!this._overlayId) {
@@ -24,7 +27,7 @@ export class OverlayPositionSample1Component implements OnDestroy {
                 // Pass in the positioning strategy
                 positionStrategy: new ConnectedPositioningStrategy()
             };
-            this._overlayId = this.overlayService.attach(MyDynamicCardComponent, overlaySettings);
+            this._overlayId = this.overlayService.attach(MyDynamicCardComponent, this.viewContainerRef, overlaySettings);
         }
 
         this.overlayService.show(this._overlayId);

--- a/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.html
+++ b/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <button class="igx-button--raised" #buttonElement igxButton (click)='showOverlay()'>
+    <button class="button" #buttonElement igxButton="raised" (click)="showOverlay()">
         Show Card
     </button>
 </div>

--- a/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.scss
+++ b/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.scss
@@ -2,7 +2,7 @@
     width: 100%;
     height: 100%;
 }
-button {
+.button {
     margin-top: 270px;
     margin-left: calc(50% - 80px);
     width: 160px;

--- a/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.ts
+++ b/src/app/interactions/overlay/overlay-positioning-2/overlay-position-sample-2.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
 import {
     ConnectedPositioningStrategy,
     HorizontalAlignment,
@@ -19,7 +19,10 @@ export class OverlayPositionSample2Component implements OnDestroy {
     private buttonElement: ElementRef;
     private _overlayId: string;
 
-    constructor(@Inject(IgxOverlayService) public overlayService: IgxOverlayService) { }
+    constructor(
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public showOverlay() {
         if (!this._overlayId) {
@@ -37,7 +40,7 @@ export class OverlayPositionSample2Component implements OnDestroy {
                 // Pass in the positioning strategy
                 positionStrategy: strategy
             };
-            this._overlayId = this.overlayService.attach(MyDynamicCardComponent, overlaySettings);
+            this._overlayId = this.overlayService.attach(MyDynamicCardComponent, this.viewContainerRef, overlaySettings);
         }
 
         this.overlayService.show(this._overlayId);

--- a/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.html
+++ b/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.html
@@ -1,5 +1,5 @@
 <div class="content">
-    <button class="igx-button--raised" #buttonElement igxButton (click)='showOverlay()'>
+    <button class="button" #buttonElement igxButton="raised" (click)="showOverlay()">
         Show Card
     </button>
 </div>

--- a/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.scss
+++ b/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.scss
@@ -2,7 +2,7 @@
     width: 100%;
     height: 100%;
 }
-button {
+.button {
     margin-top: 270px;
     margin-left: calc(50% - 80px);
     width: 160px;

--- a/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.ts
+++ b/src/app/interactions/overlay/overlay-positioning-3/overlay-position-sample-3.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnDestroy, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, ViewChild, ViewContainerRef } from '@angular/core';
 import { AutoPositionStrategy, IgxOverlayService } from 'igniteui-angular';
 import { MyDynamicCardComponent } from '../overlay-dynamic-card/overlay-dynamic-card.component';
 @Component({
@@ -12,13 +12,16 @@ export class OverlayPositionSample3Component implements OnDestroy {
     private buttonElement: ElementRef;
     private _overlayId: string;
 
-    constructor(@Inject(IgxOverlayService) public overlayService: IgxOverlayService) { }
+    constructor(
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public showOverlay() {
         if (!this._overlayId) {
             const myPositionStrategy = new AutoPositionStrategy();
             this._overlayId = this.overlayService.attach(
-                MyDynamicCardComponent, {
+                MyDynamicCardComponent, this.viewContainerRef, {
                     target: this.buttonElement.nativeElement,
                     positionStrategy: myPositionStrategy
                 });

--- a/src/app/interactions/overlay/overlay-preset-settings/overlay-preset-settings-sample.component.ts
+++ b/src/app/interactions/overlay/overlay-preset-settings/overlay-preset-settings-sample.component.ts
@@ -4,7 +4,8 @@ import {
     Inject,
     OnDestroy,
     OnInit,
-    ViewChild
+    ViewChild,
+    ViewContainerRef
 } from '@angular/core';
 import {
     AbsolutePosition,
@@ -62,7 +63,10 @@ export class OverlayPresetSettingsSampleComponent implements OnInit, OnDestroy {
     private _overlayId: string;
     private _overlaySettings: OverlaySettings;
 
-    constructor(@Inject(IgxOverlayService) public overlayService: IgxOverlayService) { }
+    constructor(
+        @Inject(IgxOverlayService) public overlayService: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) { }
 
     public ngOnInit(): void {
         this.setRelativeOverlaySettings();
@@ -82,6 +86,7 @@ export class OverlayPresetSettingsSampleComponent implements OnInit, OnDestroy {
         }
         this._overlayId = this.overlayService.attach(
             MyDynamicCardComponent,
+            this.viewContainerRef,
             this._overlaySettings
         );
         this.overlayService.show(this._overlayId);

--- a/src/app/interactions/overlay/overlay-scroll-2/overlay-scroll-sample-2.component.ts
+++ b/src/app/interactions/overlay/overlay-scroll-2/overlay-scroll-sample-2.component.ts
@@ -1,4 +1,4 @@
-import { Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild } from '@angular/core';
+import { Component, ElementRef, Inject, OnDestroy, OnInit, ViewChild, ViewContainerRef } from '@angular/core';
 import {
     AbsoluteScrollStrategy,
     BlockScrollStrategy,
@@ -32,16 +32,18 @@ export class OverlayScrollSample2Component implements OnInit, OnDestroy {
     private _target: HTMLElement;
 
     constructor(
-        @Inject(IgxOverlayService) public overlay: IgxOverlayService) {
-            this.overlay.opening
-                .pipe(takeUntil(this.destroy$))
-                .subscribe(() => this.previewHidden = true);
+        @Inject(IgxOverlayService) public overlay: IgxOverlayService,
+        public viewContainerRef: ViewContainerRef
+    ) {
+        this.overlay.opening
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.previewHidden = true);
 
-            this.overlay
-                .closed
-                .pipe(takeUntil(this.destroy$))
-                .subscribe(() => this.previewHidden = false);
-        }
+        this.overlay
+            .closed
+            .pipe(takeUntil(this.destroy$))
+            .subscribe(() => this.previewHidden = false);
+    }
 
     public ngOnInit(): void {
         (this.mainContainer.nativeElement as HTMLElement).style.height = '450px';
@@ -77,7 +79,7 @@ export class OverlayScrollSample2Component implements OnInit, OnDestroy {
             this.overlay.detach(this._overlayId);
             delete this._overlayId;
         }
-        this._overlayId = this.overlay.attach(MyDynamicCardComponent, {
+        this._overlayId = this.overlay.attach(MyDynamicCardComponent, this.viewContainerRef, {
             target: this._target,
             positionStrategy,
             scrollStrategy,


### PR DESCRIPTION
Closes #3328 

Issue-related changes are in the ts files.

This PR also includes refactoring:
- The button styling was not applied properly which caused some samples not to be displayed as expected.

For example:
![overlay](https://github.com/IgniteUI/igniteui-angular-samples/assets/49126110/5770842c-8b82-4eac-9fcb-9e3387aecb45)

- Changed the `overlay-dynamic-card.component.html` since the `igx-card-content__text` is not present in Ignite UI for Angular and the `igxCardHeaderTitle` and `igxCardHeaderSubtitle` directives apply the respective `igx-card-header__title` and `igx-card-header__subtitle` classes.
