### PR TITLE
refactor(grids): cleanup search samples

### DIFF
--- a/projects/app-crm/src/app/grid-crm/grid-crm.component.html
+++ b/projects/app-crm/src/app/grid-crm/grid-crm.component.html
@@ -25,12 +25,12 @@
                             <input #search1 name="search" id="search1" class="searchInput" igxInput placeholder="Search" [(ngModel)]="searchText" (ngModelChange)="grid1.findNext(searchText, caseSensitive)" (keydown)="searchKeyDown($event)" />
 
                             <igx-suffix *ngIf="searchText.length > 0">
-                                <div class="resultsText" *ngIf="grid1.lastSearchInfo">
-                                    <span *ngIf="grid1.lastSearchInfo.matchInfoCache.length > 0">
+                                <div class="resultsText">
+                                    <span *ngIf="grid1.lastSearchInfo.matchCount > 0">
                                         {{ grid1.lastSearchInfo.activeMatchIndex + 1 }} of {{
-                                        grid1.lastSearchInfo.matchInfoCache.length }} results
+                                        grid1.lastSearchInfo.matchCount }} results
                                     </span>
-                                    <span *ngIf="grid1.lastSearchInfo.matchInfoCache.length === 0">
+                                    <span *ngIf="grid1.lastSearchInfo.matchCount === 0">
                                         No results
                                     </span>
                                 </div>

--- a/src/app/grid/grid-search-sample/grid-search-sample.component.html
+++ b/src/app/grid/grid-search-sample/grid-search-sample.component.html
@@ -9,12 +9,12 @@
             (keydown)="searchKeyDown($event)" />
 
         <igx-suffix *ngIf="searchText.length > 0">
-            <div class="resultsText" *ngIf="grid.lastSearchInfo">
-                <span *ngIf="grid.lastSearchInfo.matchInfoCache.length > 0">
-                    {{ grid.lastSearchInfo.activeMatchIndex + 1 }} of {{ grid.lastSearchInfo.matchInfoCache.length }}
+            <div class="resultsText">
+                <span *ngIf="grid.lastSearchInfo.matchCount > 0">
+                    {{ grid.lastSearchInfo.activeMatchIndex + 1 }} of {{ grid.lastSearchInfo.matchCount }}
                     results
                 </span>
-                <span *ngIf="grid.lastSearchInfo.matchInfoCache.length === 0">
+                <span *ngIf="grid.lastSearchInfo.matchCount === 0">
                     No results
                 </span>
             </div>

--- a/src/app/tree-grid/tree-grid-search-sample/tree-grid-search-sample.component.html
+++ b/src/app/tree-grid/tree-grid-search-sample/tree-grid-search-sample.component.html
@@ -9,12 +9,12 @@
             (keydown)="searchKeyDown($event)" />
 
         <igx-suffix *ngIf="searchText.length > 0">
-            <div class="resultsText" *ngIf="treeGrid.lastSearchInfo">
-                <span *ngIf="treeGrid.lastSearchInfo.matchInfoCache.length > 0">
-                    {{ treeGrid.lastSearchInfo.activeMatchIndex + 1 }} of {{ treeGrid.lastSearchInfo.matchInfoCache.length }}
+            <div class="resultsText">
+                <span *ngIf="treeGrid.lastSearchInfo.matchCount > 0">
+                    {{ treeGrid.lastSearchInfo.activeMatchIndex + 1 }} of {{ treeGrid.lastSearchInfo.matchCount }}
                     results
                 </span>
-                <span *ngIf="treeGrid.lastSearchInfo.matchInfoCache.length === 0">
+                <span *ngIf="treeGrid.lastSearchInfo.matchCount === 0">
                     No results
                 </span>
             </div>


### PR DESCRIPTION
`lastSearchInfo.matchInfoCache.length` -> `lastSearchInfo.matchCount` and removed the check for the entire object since that does nothing