### PR TITLE
fix(grid,filtering): clear filter with empty input

### DIFF
--- a/projects/app-lob/src/app/grid/grid-boston-marathon/grid.component.ts
+++ b/projects/app-lob/src/app/grid/grid-boston-marathon/grid.component.ts
@@ -197,8 +197,12 @@ export class GridComponent implements OnInit, OnDestroy, AfterViewInit {
     }
 
     public filter(target: EventTarget): void {
-        this.grid1.filter('CountryName', (target as HTMLInputElement).value, IgxStringFilteringOperand.instance().condition('contains'), true);
-        this.grid1.markForCheck();
+        const value = (target as HTMLInputElement).value;
+        if (value) {
+            this.grid1.filter('CountryName', value, IgxStringFilteringOperand.instance().condition('contains'));
+        } else {
+            this.grid1.clearFilter('CountryName');
+        }
     }
 
     public showAlert(element: ElementRef): void {

--- a/src/app/grid/grid-filtering-sample/grid-filtering-sample.component.ts
+++ b/src/app/grid/grid-filtering-sample/grid-filtering-sample.component.ts
@@ -21,7 +21,12 @@ export class FilteringSampleComponent implements OnInit {
     }
 
     public filter(target: EventTarget) {
-        this.grid1.filter('ProductName', (target as HTMLInputElement).value, IgxStringFilteringOperand.instance().condition('contains'));
+        const value = (target as HTMLInputElement).value;
+        if (value) {
+            this.grid1.filter('ProductName', value, IgxStringFilteringOperand.instance().condition('contains'));
+        } else {
+            this.grid1.clearFilter('ProductName');
+        }
     }
 
     public formatDate(val: Date) {

--- a/src/app/tree-grid/tree-grid-filtering-sample/tree-grid-filtering-sample.component.ts
+++ b/src/app/tree-grid/tree-grid-filtering-sample/tree-grid-filtering-sample.component.ts
@@ -27,7 +27,12 @@ export class TreeGridFilteringSampleComponent implements OnInit {
     }
 
     public filter(element: EventTarget) {
-        this.treegrid1.filter('Name', (element as HTMLInputElement).value, IgxStringFilteringOperand.instance().condition('contains'));
+        const value = (element as HTMLInputElement).value;
+        if (value) {
+            this.treegrid1.filter('Name', value, IgxStringFilteringOperand.instance().condition('contains'));
+        } else {
+            this.treegrid1.clearFilter('Name');
+        }
     }
 
     public formatDate(val: Date) {


### PR DESCRIPTION
In the Filtering samples for Grid & Tree Grid, when you enter a filter value the Filter UI chip on the respective column is added, except when the filter input is cleared it remains with no value:
https://www.infragistics.com/products/ignite-ui-angular/angular/components/grid/filtering#angular-grid-filtering-example
![image](https://github.com/user-attachments/assets/540fb3bf-fef7-490b-ad6d-9869a61af2a2)
https://www.infragistics.com/products/ignite-ui-angular/angular/components/treegrid/filtering#angular-tree-grid-filtering-example
![image](https://github.com/user-attachments/assets/e13ed040-a3ce-478c-85ce-0b32c975381a)

~Technically the same should be applied to the Boston Marathon and Filter template samples, since those do the same, except the UI is not active and thus isn't visible.~ Strike that, the Filter template samples actually have a check and clear, leaving just the landing grid sample, so I'll just go ahead and update it as well.