### PR TITLE
Argument palette removed from color-classes mixin

### DIFF
--- a/src/app/theming/angular/angular-sample.component.scss
+++ b/src/app/theming/angular/angular-sample.component.scss
@@ -139,7 +139,7 @@ igx-expansion-panel-body {
     @include typography($font-family: $material-typeface, $type-scale: $material-type-scale);
 
     &.light {
-        @include color-classes($palette: $igx-light-palette, $prop: "background", $prefix: "bg");
+        @include color-classes($prop: "background", $prefix: "bg");
 
         background: color($igx-light-palette, 'surface');
 
@@ -159,7 +159,7 @@ igx-expansion-panel-body {
     }
 
     &.dark {
-        @include color-classes($palette: $custom-dark-palette, $prop: "background", $prefix: "bg");
+        @include color-classes($prop: "background", $prefix: "bg");
 
         background: color($custom-dark-palette, 'surface');
 

--- a/src/app/theming/bootstrap/bootstrap-sample.component.scss
+++ b/src/app/theming/bootstrap/bootstrap-sample.component.scss
@@ -51,7 +51,6 @@ $dark-secondary: color($custom-dark-palette, "secondary");
 
     &.light {
         @include color-classes(
-            $palette: $light-bootstrap-palette,
             $prop: 'background',
             $prefix: 'bg'
         );
@@ -78,7 +77,6 @@ $dark-secondary: color($custom-dark-palette, "secondary");
 
     &.dark {
         @include color-classes(
-            $palette: $custom-dark-palette,
             $prop: 'background',
             $prefix: 'bg'
         );


### PR DESCRIPTION
Argument **palette** is no longer used and throws errors on build