### PR TITLE
fix(tooltip-advanced): use local path to images

### DIFF
--- a/src/app/interactions/tooltip/tooltip-advanced/tooltip-advanced.component.html
+++ b/src/app/interactions/tooltip/tooltip-advanced/tooltip-advanced.component.html
@@ -73,7 +73,7 @@
                 <div class="avatarWrapper" igxListThumbnail>
                     <igx-avatar
                         id="avatar"
-                        src="https://www.infragistics.com/angular-demos-lob/assets/images/avatar/10.jpg"
+                        src="assets/images/avatar/10.jpg"
                         shape="circle"
                     >
                     </igx-avatar>
@@ -89,7 +89,7 @@
         <div class="avatarWrapper">
             <igx-avatar
                 id="avatar"
-                src="https://www.infragistics.com/angular-demos-lob/assets/images/avatar/10.jpg"
+                src="assets/images/avatar/10.jpg"
                 shape="circle"
             >
             </igx-avatar>
@@ -113,7 +113,7 @@
                 <div class="avatarWrapper" igxListThumbnail>
                     <igx-avatar
                         id="avatar"
-                        src="https://www.infragistics.com/angular-demos-lob/assets/images/avatar/5.jpg"
+                        src="assets/images/avatar/5.jpg"
                         shape="circle"
                     >
                     </igx-avatar>


### PR DESCRIPTION
Closes #3920

### For testing
Run the PR with `npm run start:live-editing`
Run igniteui-docfx with `npm run start:en`
Observe the Advanced Example HTML content http://localhost:3000/components/tooltip.html#advanced-example
Check it in StackBlitz too

<img width="1105" height="709" alt="image" src="https://github.com/user-attachments/assets/03707b41-a643-47a5-9776-ddae24abf4ec" />
